### PR TITLE
Add BSD-3-Clause licensing option (#29)

### DIFF
--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,26 @@
+Copyright (c) 2021 pypdfium2-team.
+
+Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this 
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, 
+this list of conditions and the following disclaimer in the documentation and/or 
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors 
+may be used to endorse or promote products derived from this software without 
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR 
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON 
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/build.py
+++ b/build.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 # Attempt to build PDFium from source. This may take very long.
 # Last confirmed to work on 2021-12-13

--- a/clean.sh
+++ b/clean.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 rm -r dist
 rm -r build

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
 sphinx
 sphinx-rtd-theme

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 bash clean.sh
 python3 update.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 [metadata]
 name = pypdfium2

--- a/setup_all.sh
+++ b/setup_all.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 python3 setup_darwin_x64.py   bdist_wheel
 python3 setup_darwin_arm64.py bdist_wheel

--- a/setup_base.py
+++ b/setup_base.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import os
 from os.path import (

--- a/setup_darwin_arm64.py
+++ b/setup_darwin_arm64.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 from setup_base import *
 

--- a/setup_darwin_x64.py
+++ b/setup_darwin_x64.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 from setup_base import *
 

--- a/setup_linux_arm32.py
+++ b/setup_linux_arm32.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 from setup_base import *
 

--- a/setup_linux_arm64.py
+++ b/setup_linux_arm64.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 from setup_base import *
 

--- a/setup_linux_x64.py
+++ b/setup_linux_x64.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 from setup_base import *
 

--- a/setup_source.py
+++ b/setup_source.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import os
 import distutils.util

--- a/setup_windows_x64.py
+++ b/setup_windows_x64.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 from setup_base import *
 

--- a/setup_windows_x86.py
+++ b/setup_windows_x86.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 from setup_base import *
 

--- a/src/pypdfium2/__init__.py
+++ b/src/pypdfium2/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import logging
 from pypdfium2._logging import setup_logger

--- a/src/pypdfium2/__main__.py
+++ b/src/pypdfium2/__main__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import os
 import sys

--- a/src/pypdfium2/_constants.py
+++ b/src/pypdfium2/_constants.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 from enum import Enum
 

--- a/src/pypdfium2/_exceptions.py
+++ b/src/pypdfium2/_exceptions.py
@@ -28,3 +28,9 @@ class PageIndexError (IndexError):
 
 class RecusionLimitError (RuntimeError):
     """ Raised if a recursion depth limit is exceeded. """
+    pass
+
+
+class CircularRefError (RuntimeError):
+    """ Raised if a circular reference was detected that would result in an endless loop. """
+    pass

--- a/src/pypdfium2/_exceptions.py
+++ b/src/pypdfium2/_exceptions.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 
 class PdfiumError (RuntimeError):

--- a/src/pypdfium2/_helpers.py
+++ b/src/pypdfium2/_helpers.py
@@ -482,6 +482,7 @@ def get_toc(
         parent: Optional[pdfium.FPDF_BOOKMARK] = None,
         level: int = 0,
         max_depth: int = 15,
+        seen: Optional[list] = None,
     ) -> Iterator[OutlineItem]:
     """
     Read the table of contents ("outline") of a PDF document.
@@ -501,12 +502,21 @@ def get_toc(
     
     bookmark = pdfium.FPDFBookmark_GetFirstChild(pdf, parent)
     
+    if seen is None:
+        seen = []
+    
     while bookmark:
+        
+        address = ctypes.addressof(bookmark.contents)
+        if address in seen:
+            raise CircularRefError("A circular bookmark reference was detected whilst parsing the table of contents.")
+        else:
+            seen.append(address)
         
         item = _get_toc_entry(pdf, bookmark, level)
         yield item
         
-        for child in get_toc(pdf, bookmark, level=level+1, max_depth=max_depth):
+        for child in get_toc(pdf, bookmark, level=level+1, max_depth=max_depth, seen=seen):
             yield child
         
         bookmark = pdfium.FPDFBookmark_GetNextSibling(pdf, bookmark)

--- a/src/pypdfium2/_helpers.py
+++ b/src/pypdfium2/_helpers.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import io
 import os

--- a/src/pypdfium2/_logging.py
+++ b/src/pypdfium2/_logging.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import logging
 

--- a/src/pypdfium2/_types.py
+++ b/src/pypdfium2/_types.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import ctypes
 import pypdfium2._pypdfium as pdfium

--- a/src/pypdfium2/_version.py
+++ b/src/pypdfium2/_version.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 V_MAJOR = 0
 V_MINOR = 4

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-FileCopyrightText: 2021 Adam Huganir <adam@huganir.com>
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import pytest
 from pathlib import Path

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import io
 import pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2021 Adam Huganir <adam@huganir.com>
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import pytest
 from pypdfium2 import __main__ as main

--- a/update.py
+++ b/update.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 # SPDX-FileCopyrightText: 2021 geisserml <geisserml@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 # Download the PDFium binaries and generate ctypes bindings
 # Last confirmed to work on 2021-12-13


### PR DESCRIPTION
See discussion https://github.com/pypdfium2-team/pypdfium2/discussions/29

I hope I haven't missed anything. To avoid doubts in case I did miss something, this PR intends to re-license all files that previously had the identifier `Apache-2.0` to `Apache-2.0 OR BSD-3-Clause`.