### PR TITLE
Integrate support for Windows ARM64

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,4 +5,4 @@
 bash clean.sh
 python3 update.py
 bash setup_all.sh
-check-wheel-contents dist/*
+check-wheel-contents dist/*.whl

--- a/setup_all.sh
+++ b/setup_all.sh
@@ -2,11 +2,12 @@
 # SPDX-FileCopyrightText: 2022 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-python3 setup_darwin_x64.py   bdist_wheel
-python3 setup_darwin_arm64.py bdist_wheel
-python3 setup_linux_x64.py    bdist_wheel
-python3 setup_linux_arm64.py  bdist_wheel
-python3 setup_linux_arm32.py  bdist_wheel
-python3 setup_windows_x64.py  bdist_wheel
-python3 setup_windows_x86.py  bdist_wheel
+python3 setup_darwin_x64.py    bdist_wheel
+python3 setup_darwin_arm64.py  bdist_wheel
+python3 setup_linux_x64.py     bdist_wheel
+python3 setup_linux_arm64.py   bdist_wheel
+python3 setup_linux_arm32.py   bdist_wheel
+python3 setup_windows_x64.py   bdist_wheel
+python3 setup_windows_x86.py   bdist_wheel
+python3 setup_windows_arm64.py bdist_wheel
 python3 setup_sdist.py sdist

--- a/setup_all.sh
+++ b/setup_all.sh
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+python3 setup_sdist.py sdist
 python3 setup_darwin_x64.py    bdist_wheel
 python3 setup_darwin_arm64.py  bdist_wheel
 python3 setup_linux_x64.py     bdist_wheel
@@ -10,4 +11,3 @@ python3 setup_linux_arm32.py   bdist_wheel
 python3 setup_windows_x64.py   bdist_wheel
 python3 setup_windows_x86.py   bdist_wheel
 python3 setup_windows_arm64.py bdist_wheel
-python3 setup_sdist.py sdist

--- a/setup_base.py
+++ b/setup_base.py
@@ -28,6 +28,7 @@ LinuxArm64   = join(DataTree,'linux-arm64')
 LinuxArm32   = join(DataTree,'linux-arm32')
 Windows64    = join(DataTree,'windows-x64')
 Windows86    = join(DataTree,'windows-x86')
+WindowsArm64 = join(DataTree,'windows-arm64')
 SourceBuild  = join(DataTree,'sourcebuild')
 
 

--- a/setup_windows_arm64.py
+++ b/setup_windows_arm64.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python3
+# SPDX-FileCopyrightText: 2022 geisserml <geisserml@gmail.com>
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+from setup_base import *
+
+class bdist (BDistBase):
+    def finalize_options(self):
+        BDistBase.finalize_options(self)
+        self.plat_name = 'win_arm64'
+
+def lib_setup():
+    setuptools.setup(
+        cmdclass = {'bdist_wheel': bdist},
+        package_data = {'': ['pdfium.dll']},
+    )
+
+if __name__ == '__main__':
+    build(lib_setup, WindowsArm64)

--- a/update.py
+++ b/update.py
@@ -134,12 +134,12 @@ def download_releases(latest_version, download_files):
         
         filename = f"{arcname}.{ReleaseExtension}"
         file_url = base_url + filename
+        
         dest_dir = join(DataTree, dirname)
         if not os.path.exists(dest_dir):
             os.mkdir(dest_dir)
         
         file_path = join(dest_dir, filename)
-        
         args.append( (dirname, file_url, file_path) )
     
     archives = {}

--- a/update.py
+++ b/update.py
@@ -201,6 +201,10 @@ def generate_bindings(archives):
                 bin_dir = join(build_dir,'x64','bin')
             elif dirname.endswith('x86'):
                 bin_dir = join(build_dir,'x86','bin')
+            elif dirname.endswith('arm64'):
+                bin_dir = join(build_dir,'arm64','bin')
+            else:
+                raise ValueError("Binary directory could not be recognised.")
             
         elif dirname.startswith('darwin'):
             

--- a/update.py
+++ b/update.py
@@ -18,6 +18,16 @@ import argparse
 import threading
 import subprocess
 from urllib import request
+from setup_base import (
+    Darwin64,
+    DarwinArm64,
+    Linux64,
+    LinuxArm64,
+    LinuxArm32,
+    Windows64,
+    Windows86,
+    WindowsArm64,
+)
 
 
 HomeDir      = os.path.expanduser('~')
@@ -27,13 +37,14 @@ DataTree     = join(SourceTree,'data')
 ReleaseURL   = 'https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F'
 ReleaseExtension = 'tgz'
 ReleaseFiles = {
-    'darwin-arm64' : 'pdfium-mac-arm64',
-    'darwin-x64'   : 'pdfium-mac-x64',
-    'linux-arm32'  : 'pdfium-linux-arm',
-    'linux-arm64'  : 'pdfium-linux-arm64',
-    'linux-x64'    : 'pdfium-linux-x64',
-    'windows-x64'  : 'pdfium-win-x64',
-    'windows-x86'  : 'pdfium-win-x86',
+    Darwin64     : 'pdfium-mac-x64',
+    DarwinArm64  : 'pdfium-mac-arm64',
+    Linux64      : 'pdfium-linux-x64',
+    LinuxArm64   : 'pdfium-linux-arm64',
+    LinuxArm32   : 'pdfium-linux-arm',
+    Windows64    : 'pdfium-win-x64',
+    Windows86    : 'pdfium-win-x86',
+    WindowsArm64 : 'pdfium-win-arm64',
 }
 
 


### PR DESCRIPTION
I'm not sure whether PyPI support `win_arm64` wheels at all, but we'll see tomorrow. The code of [`sysconfig.get_platform()`](https://github.com/python/cpython/blob/3.10/Lib/sysconfig.py#L691) suggests that it might work.