### PR TITLE
Completely restructure the setup strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: CC-BY-4.0
 
 data/
-!data/.gitkeep
+!data/setup_status.txt
 build/
 dist/
 docs/build/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: CC-BY-4.0
 
 data/
-!data/setup_status.txt
 build/
 dist/
 docs/build/*

--- a/.setup_status.txt
+++ b/.setup_status.txt
@@ -1,0 +1,1 @@
+InitialState

--- a/.setup_status.txt
+++ b/.setup_status.txt
@@ -1,1 +1,0 @@
-InitialState

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@
   build, on behalf of platforms for which no wheel is available. With this release, the code
   was changed to detect the current platform and use pre-compiled binaries if available, with
   source build only as fallback.
-- The version file is now always read literally on setup, which makes it a lot less prone to
-  errors.
+- On setup, the version file is now always read literally (i. e. without importing the module),
+  which makes it a lot less prone to errors.
 - Modernised the update script code that reads and writes the version file.
 - Updated the Makefile.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - When opening from a byte buffer, any object that implements the `.read()` method is now
   accepted (previously, only `BytesIO` and `BufferedReader` were supported). Note that we
   no longer automatically seek back to the start of the buffer.
+- Greatly improved `setup.py`: Formerly, running `pip3 install .` always triggered a source
+  build, on behalf of platforms for which no wheel is available. With this release, the code
+  was changed to detect the current platform and use pre-compiled binaries if available, with
+  source build only as fallback.
 
 ## 0.10.0 (2022-01-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   build, on behalf of platforms for which no wheel is available. With this release, the code
   was changed to detect the current platform and use pre-compiled binaries if available, with
   source build only as fallback.
-- The version file is now always read literally on setup, which makes it lot less prone to
+- The version file is now always read literally on setup, which makes it a lot less prone to
   errors.
 - Modernised the update script code that reads and writes the version file.
 - Updated the Makefile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,18 @@
 - When opening from a byte buffer, any object that implements the `.read()` method is now
   accepted (previously, only `BytesIO` and `BufferedReader` were supported). Note that we
   no longer automatically seek back to the start of the buffer.
+- Restructured installing the exit handler, so that its function is no longer inadvertently
+  part of the public namespace.
+- Removed the `None` defaults of the table of contents helper class `OutlineItem`. The
+  parameters are now passed at construction time.
 - Greatly improved `setup.py`: Formerly, running `pip3 install .` always triggered a source
   build, on behalf of platforms for which no wheel is available. With this release, the code
   was changed to detect the current platform and use pre-compiled binaries if available, with
   source build only as fallback.
+- The version file is now always read literally on setup, which makes it lot less prone to
+  errors.
+- Modernised the update script code that reads and writes the version file.
+- Updated the Makefile.
 
 ## 0.10.0 (2022-01-24)
 

--- a/DEPS.md
+++ b/DEPS.md
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 # Runtime
-* Python >= 3.6
+* Python >= 3.5
 * Pillow
 
 # Build

--- a/DEPS.md
+++ b/DEPS.md
@@ -33,3 +33,5 @@
 * make
 * importchecker
 * codespell
+* twine
+* check-wheel-contents

--- a/DEPS.md
+++ b/DEPS.md
@@ -32,3 +32,4 @@
 # Utilities
 * make
 * importchecker
+* codespell

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ update-all:
 setup-all:
 	bash ./utilities/setup_all.sh
 
-sourcebuild:
+build:
 	python3 build_pdfium.py
 	python3 setup_source.py bdist_wheel
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: 2022 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: CC-BY-4.0 
 
+install:
+	python3 -m pip install . -v
+
 release:
 	bash ./utilities/release.sh
 
@@ -11,12 +14,9 @@ update-all:
 setup-all:
 	bash ./utilities/setup_all.sh
 
-build:
+sourcebuild:
 	python3 build_pdfium.py
 	python3 setup_source.py bdist_wheel
 
 clean:
 	bash ./utilities/clean.sh
-
-compcheck:
-	python3 ./utilities/compcheck.py

--- a/README.md
+++ b/README.md
@@ -18,35 +18,38 @@ python3 -m pip install -U pypdfium2
 
 ### Manual installation
 
-The following steps require the external tools `git`, `ctypesgen` and `gcc` to be
-installed and available in `PATH`. Additionally, the python package `wheel` is required.
-
-For source build, more dependencies may be necessary (see [`DEPS.md`](DEPS.md)).
-
+The following steps require the system tools `git` and `gcc` to be installed and available
+in `PATH`. Python dependencies will be installed automatically for the current user.
+For more information, please refer to [`DEPS.md`](DEPS.md).
 
 #### Package locally
 
-This will download a pre-built binary for PDFium, generate the bindings and
-build a wheel.
-
+To get pre-compiled binaries, generate bindings and install PyPDFium2, you may run
 ```bash
-python3 update_pdfium.py -p ${platform_name}
-python3 setup_${platform_name}.py bdist_wheel
-python3 -m pip install -U dist/pypdfium2-${version}-py3-none-${platform_tag}.whl
+python3 -m pip install . -v
 ```
+in the directory you downloaded the repository to. This will resort to building PDFium
+if no pre-compiled binaries are available for your platform.
 
 #### Source build
 
-If you are using a platform where no pre-compiled package is available, it might be
-possible to build PDFium from source. However, this is a complex process that can vary
-depending on the host system, and it may take a long time.
+If you wish to perform a source build regardless of whether PDFium binaries are available or not,
+you can do the following:
 
 ```bash
-python3 build_pdfium.py
+python3 build_pdfium.py --getdeps
 python3 setup_source.py bdist_wheel
 pip3 install dist/pypdfium2-${version}-py3-none-${platform_tag}.whl
 ```
 
+`${version}` and `${platform_tag}` are placeholders that need to replaced with the values
+that correspond to your platform (e. g. `pypdfium2-0.11.0-py3-none-linux.whl`).
+
+In case building failed, you could try `python3 build_pdfium.py -p` to prefer the use of
+system-provided build tools over the toolchain PDFium ships with. This might help since the
+toolchain is limited to a curated set of platforms, as PDFium target cross-compilation for
+"non-standard" architectures. (Make sure you installed all packages from the `Native Build`
+section of [`DEPS.md`](DEPS.md), in addition to the default requirements.)
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ Run `pytest` on the `tests` directory.
 ## Issues
 
 Since PyPDFium2 is built using upstream binaries and an automatic bindings creator,
-issues that are not related to packaging most likely need to be addressed upstream.
-However, the [PyPDFium2 issues panel](https://github.com/pypdfium2-team/pypdfium2/issues)
+issues that are not related to packaging or support model code probably need to be
+addressed upstream. However, the [PyPDFium2 issues panel](https://github.com/pypdfium2-team/pypdfium2/issues)
 is always a good place to start if you have any problems, questions or suggestions.
 
 If the cause of an issue could be determined to be in PDFium, the problem needs to be
@@ -266,9 +266,9 @@ If your issue is caused by the bindings generator, refer to the
 
 ### Non-ascii file paths on Windows
 
-On Windows, PDFium currently is not able to open documents with file names containing multi-byte, non-ascii
-characters. This issue is [confirmed upstream](https://bugs.chromium.org/p/pdfium/issues/detail?id=682), but
-has not been addressed yet.
+On Windows, PDFium currently is not able to open documents with file names containing
+multi-byte, non-ascii characters. This issue is [confirmed upstream](https://bugs.chromium.org/p/pdfium/issues/detail?id=682),
+but has not been addressed yet.
 
   
 ## Thanks

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ pip3 install dist/pypdfium2-${version}-py3-none-${platform_tag}.whl
 `${version}` and `${platform_tag}` are placeholders that need to replaced with the values
 that correspond to your platform (e. g. `pypdfium2-0.11.0-py3-none-linux.whl`).
 
-In case building failed, you could try `python3 build_pdfium.py -p` to prefer the use of
-system-provided build tools over the toolchain PDFium ships with. This might help since the
-toolchain is limited to a curated set of platforms, as PDFium target cross-compilation for
-"non-standard" architectures. (Make sure you installed all packages from the `Native Build`
+In case building failed, you could try `python3 build_pdfium.py --getdeps -p` to prefer the
+use of system-provided build tools over the toolchain PDFium ships with. This might help
+since the toolchain is limited to a curated set of platforms, as PDFium target cross-compilation
+for "non-standard" architectures. (Make sure you installed all packages from the `Native Build`
 section of [`DEPS.md`](DEPS.md), in addition to the default requirements.)
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python3 setup_source.py bdist_wheel
 pip3 install dist/pypdfium2-${version}-py3-none-${platform_tag}.whl
 ```
 
-`${version}` and `${platform_tag}` are placeholders that need to replaced with the values
+`${version}` and `${platform_tag}` are placeholders that need to be replaced with the values
 that correspond to your platform (e. g. `pypdfium2-0.11.0-py3-none-linux.whl`).
 
 In case building failed, you could try `python3 build_pdfium.py --getdeps -p` to prefer the

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ is always a good place to start if you have any problems, questions or suggestio
 If the cause of an issue could be determined to be in PDFium, the problem needs to be
 reported at the [PDFium bug tracker](https://bugs.chromium.org/p/pdfium/issues/list).
 
-Issues related to build configuration should be discussed at
+Issues related to pre-compiled binaries should be discussed at
 [pdfium-binaries](https://github.com/bblanchon/pdfium-binaries/issues), though.
 
 If your issue is caused by the bindings generator, refer to the

--- a/TASKS.md
+++ b/TASKS.md
@@ -12,8 +12,6 @@ PyPDFium2 Tasks
 * Read the version differently in setup, as shown in `PIL` and `archive-pdf-tools`, because it seems like the `attr:`
   directive (at least under some conditions) does not extract the version value literally (that is, without trying to
   import the module).
-* Change `setup.py` to use a pre-compiled platform-specific binary if available. Otherwise, try to do a source build.
-  (Maybe ask the user beforehand.) Consider a fallback to system-provided tools if regular build failed.
 * Add means for automatic system dependency installation on Linux. Prompt the user for the admin password using `sudo`,
   `pkexec` or similar.
 * Remove the KDevelop project from the repository.

--- a/TASKS.md
+++ b/TASKS.md
@@ -4,7 +4,6 @@ PyPDFium2 Tasks
 (These are various tasks for the maintainer to keep in mind, in no specific order.)
 
 * Ask Linux distributors to package PDFium, as this could greatly simplify the installation of PyPDFium2 for many users. Since most distributions are already compiling PDFium for their Chromium package anyway, it should be feasible to build PDFium as a dynamically linked library and add a development package containing the header files. We could then add a custom setup file that will create bindings using the system-provided PDFium headers.
-* Improve getting and setting the version when updating binaries/bindings.
 * Set the version appropriately when doing a source build (i. e. append current PDFium commit hash to version string).
 * Add means for automatic system dependency installation on Linux. Prompt the user for the admin password using `sudo`, `pkexec` or similar.
 * Move Changelog and Contributing Guidelines into the Sphinx documentation.

--- a/TASKS.md
+++ b/TASKS.md
@@ -9,9 +9,6 @@ PyPDFium2 Tasks
   then add a custom setup file that will create bindings using the system-provided PDFium headers.
 * Improve getting and setting the version when updating binaries/bindings.
 * Set the version appropriately when doing a source build (i. e. append current PDFium commit hash to version string).
-* Read the version differently in setup, as shown in `PIL` and `archive-pdf-tools`, because it seems like the `attr:`
-  directive (at least under some conditions) does not extract the version value literally (that is, without trying to
-  import the module).
 * Add means for automatic system dependency installation on Linux. Prompt the user for the admin password using `sudo`,
   `pkexec` or similar.
 * Move Changelog and Contributing Guidelines into the Sphinx documentation.

--- a/TASKS.md
+++ b/TASKS.md
@@ -14,7 +14,6 @@ PyPDFium2 Tasks
   import the module).
 * Add means for automatic system dependency installation on Linux. Prompt the user for the admin password using `sudo`,
   `pkexec` or similar.
-* Remove the KDevelop project from the repository.
 * Move Changelog and Contributing Guidelines into the Sphinx documentation.
 * Think about how to prevent further growth of the repository root directory.
 * Decide what to do about the kind of failed `compcheck.py` utility.

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,25 +3,16 @@ PyPDFium2 Tasks
 
 (These are various tasks for the maintainer to keep in mind, in no specific order.)
 
-* Ask Linux distributors to package PDFium, as this could greatly simplify the installation of PyPDFium2 for many users.
-  Since most distributions are already compiling PDFium for their Chromium package anyway, it should be feasible to
-  build PDFium as a dynamically linked library and add a development package containing the header files. We could
-  then add a custom setup file that will create bindings using the system-provided PDFium headers.
+* Ask Linux distributors to package PDFium, as this could greatly simplify the installation of PyPDFium2 for many users. Since most distributions are already compiling PDFium for their Chromium package anyway, it should be feasible to build PDFium as a dynamically linked library and add a development package containing the header files. We could then add a custom setup file that will create bindings using the system-provided PDFium headers.
 * Improve getting and setting the version when updating binaries/bindings.
 * Set the version appropriately when doing a source build (i. e. append current PDFium commit hash to version string).
-* Add means for automatic system dependency installation on Linux. Prompt the user for the admin password using `sudo`,
-  `pkexec` or similar.
+* Add means for automatic system dependency installation on Linux. Prompt the user for the admin password using `sudo`, `pkexec` or similar.
 * Move Changelog and Contributing Guidelines into the Sphinx documentation.
 * Think about how to prevent further growth of the repository root directory.
 * Decide what to do about the kind of failed `compcheck.py` utility.
 * Look into setting up Github Actions CI.
-* Create a `.readthedocs.yaml` configuration file (issue #32). In general, improve RTD configuration to prevent similar
-  trouble like issue #53. It would be nice if we could sync RTD with PyPI rather than GitHub, but there currently doesn't
-  seem to be an obvious way. Perhaps we should create a dedicated `docs` branch that RTD is synced with, and update that
-  branch with every release.
+* Create a `.readthedocs.yaml` configuration file (issue #32). In general, improve RTD configuration to prevent similar trouble like issue #53. It would be nice if we could sync RTD with PyPI rather than GitHub, but there currently doesn't seem to be an obvious way. Perhaps we should create a dedicated `docs` branch that RTD is synced with, and update that branch with every release.
 * Add capabilities to render a certain area of a page (issue #38).
-* Allow for only returning bytes rather than creating an `Image.Image` object when rendering, so that callers may use the
-  data in any way they like, without having to go through an intermediate PIL object (e. g. directly inject the data into
-  a GUI widget buffer).
+* Allow for only returning bytes rather than creating an `Image.Image` object when rendering, so that callers may use the data in any way they like, without having to go through an intermediate PIL object (e. g. directly inject the data into a GUI widget buffer).
 * Investigate what can be done regarding compatibility with legacy setuptools versions (issue #52).
 * Think about further extending support for older Python versions (see changelog).

--- a/_getdeps.py
+++ b/_getdeps.py
@@ -45,7 +45,7 @@ def install_ctypesgen():
         run_cmd("git clone {}".format(Ctypesgen_URL), cwd=SB_Dir)
     
     run_cmd("git checkout {}".format(Ctypesgen_PIN), cwd=Ctypesgen_Dir)
-    run_cmd("pip3 install -U . -v", cwd=Ctypesgen_Dir)
+    run_cmd("pip3 install -U .", cwd=Ctypesgen_Dir)
 
 
 def install_pydeps():

--- a/_packaging.py
+++ b/_packaging.py
@@ -23,6 +23,7 @@ Libnames = [
 
 HomeDir    = expanduser('~')
 SourceTree = dirname(abspath(__file__))
+DataTree   = join(SourceTree,'data')
 SB_Dir     = join(SourceTree,'sourcebuild')
 
 

--- a/_packaging.py
+++ b/_packaging.py
@@ -21,10 +21,11 @@ Libnames = [
 ]
 
 
-HomeDir    = expanduser('~')
-SourceTree = dirname(abspath(__file__))
-DataTree   = join(SourceTree,'data')
-SB_Dir     = join(SourceTree,'sourcebuild')
+HomeDir     = expanduser('~')
+SourceTree  = dirname(abspath(__file__))
+DataTree    = join(SourceTree,'data')
+SB_Dir      = join(SourceTree,'sourcebuild')
+VersionFile = join(SourceTree,'src','pypdfium2','_version.py')
 
 
 def run_cmd(command, cwd):
@@ -46,11 +47,9 @@ def postprocess_bindings(bindings_file, platform_dir):
 
 def _get_ver_namespace():
     
-    ver_path = join(SourceTree,'src','pypdfium2','_version.py')
-    
     ver_namespace = {}
-    with open(ver_path) as ver_file:
-        exec(ver_file.read(), ver_namespace)
+    with open(VersionFile) as fh:
+        exec(fh.read(), ver_namespace)
     
     return ver_namespace
 

--- a/_packaging.py
+++ b/_packaging.py
@@ -42,3 +42,14 @@ def postprocess_bindings(bindings_file, platform_dir):
     
     with open(bindings_file, 'w') as file_writer:
         file_writer.write(text)
+
+
+def get_version_namespace():
+    
+    ver_path = join(SourceTree,'src','pypdfium2','_version.py')
+    
+    ver_namespace = {}
+    with open(ver_path) as ver_file:
+        exec(ver_file.read(), ver_namespace)
+    
+    return ver_namespace

--- a/_packaging.py
+++ b/_packaging.py
@@ -44,7 +44,7 @@ def postprocess_bindings(bindings_file, platform_dir):
         file_writer.write(text)
 
 
-def get_version_namespace():
+def _get_ver_namespace():
     
     ver_path = join(SourceTree,'src','pypdfium2','_version.py')
     
@@ -53,3 +53,9 @@ def get_version_namespace():
         exec(ver_file.read(), ver_namespace)
     
     return ver_namespace
+
+
+_ver_namespace = _get_ver_namespace()
+
+def extract_version(variable_str):
+    return _ver_namespace[variable_str]

--- a/_setup_base.py
+++ b/_setup_base.py
@@ -69,11 +69,14 @@ def _clean():
 
 
 def _copy_bindings(platform_dir):
-    platform_files = glob(join(platform_dir,'*'))
-    for src in platform_files:
-        if os.path.isfile(src):
-            dest = join(TargetDir, basename(src))
-            shutil.copy(src, dest)
+    
+    # non-recursively collect all objects from the platform directory
+    for src_path in glob(join(platform_dir,'*')):
+        
+        # copy platform-specific files into the sources, excluding possible directories
+        if os.path.isfile(src_path):
+            dest = join(TargetDir, basename(src_path))
+            shutil.copy(src_path, dest)
 
 
 def build(lib_setup: Callable, platform_dir):

--- a/_setup_base.py
+++ b/_setup_base.py
@@ -15,7 +15,10 @@ import setuptools
 from glob import glob
 from typing import Callable
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-from _packaging import Libnames
+from _packaging import (
+    Libnames,
+    get_version_namespace,
+)
 
 
 SourceTree = dirname(realpath(__file__))
@@ -32,6 +35,12 @@ class PlatformDirs:
     Windows86    = join(DataTree,'windows-x86')
     WindowsArm64 = join(DataTree,'windows-arm64')
     #SourceBuild  = join(DataTree,'sourcebuild')
+
+
+version = get_version_namespace()['V_PYPDFIUM2']
+SetupKws = dict(
+    version = version,
+)
 
 
 class BDistBase (_bdist_wheel):

--- a/_setup_base.py
+++ b/_setup_base.py
@@ -75,8 +75,8 @@ def _copy_bindings(platform_dir):
         
         # copy platform-specific files into the sources, excluding possible directories
         if os.path.isfile(src_path):
-            dest = join(TargetDir, basename(src_path))
-            shutil.copy(src_path, dest)
+            dest_path = join(TargetDir, basename(src_path))
+            shutil.copy(src_path, dest_path)
 
 
 def build(lib_setup: Callable, platform_dir):

--- a/_setup_base.py
+++ b/_setup_base.py
@@ -34,7 +34,7 @@ class PlatformDirs:
     Windows64    = join(DataTree,'windows-x64')
     Windows86    = join(DataTree,'windows-x86')
     WindowsArm64 = join(DataTree,'windows-arm64')
-    #SourceBuild  = join(DataTree,'sourcebuild')
+    SourceBuild  = join(DataTree,'sourcebuild')
 
 
 SetupKws = dict(

--- a/_setup_base.py
+++ b/_setup_base.py
@@ -17,7 +17,7 @@ from typing import Callable
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 from _packaging import (
     Libnames,
-    get_version_namespace,
+    extract_version,
 )
 
 
@@ -37,9 +37,8 @@ class PlatformDirs:
     #SourceBuild  = join(DataTree,'sourcebuild')
 
 
-version = get_version_namespace()['V_PYPDFIUM2']
 SetupKws = dict(
-    version = version,
+    version = extract_version('V_PYPDFIUM2'),
 )
 
 

--- a/_setup_base.py
+++ b/_setup_base.py
@@ -22,15 +22,16 @@ SourceTree = dirname(realpath(__file__))
 TargetDir  = join(SourceTree,'src','pypdfium2')
 DataTree   = join(SourceTree,'data')
 
-Darwin64     = join(DataTree,'darwin-x64')
-DarwinArm64  = join(DataTree,'darwin-arm64')
-Linux64      = join(DataTree,'linux-x64')
-LinuxArm64   = join(DataTree,'linux-arm64')
-LinuxArm32   = join(DataTree,'linux-arm32')
-Windows64    = join(DataTree,'windows-x64')
-Windows86    = join(DataTree,'windows-x86')
-WindowsArm64 = join(DataTree,'windows-arm64')
-SourceBuild  = join(DataTree,'sourcebuild')
+class PlatformDirs:
+    Darwin64     = join(DataTree,'darwin-x64')
+    DarwinArm64  = join(DataTree,'darwin-arm64')
+    Linux64      = join(DataTree,'linux-x64')
+    LinuxArm64   = join(DataTree,'linux-arm64')
+    LinuxArm32   = join(DataTree,'linux-arm32')
+    Windows64    = join(DataTree,'windows-x64')
+    Windows86    = join(DataTree,'windows-x86')
+    WindowsArm64 = join(DataTree,'windows-arm64')
+    #SourceBuild  = join(DataTree,'sourcebuild')
 
 
 class BDistBase (_bdist_wheel):

--- a/build_pdfium.py
+++ b/build_pdfium.py
@@ -14,15 +14,16 @@ from os.path import (
     abspath,
     basename,
 )
-from _packaging import *
 import _getdeps as getdeps
+from _packaging import *
+from _setup_base import PlatformDirs
 
 
 PatchDir       = join(SB_Dir,'patches')
 DepotToolsDir  = join(SB_Dir,'depot_tools')
 PDFiumDir      = join(SB_Dir,'pdfium')
 PDFiumBuildDir = join(PDFiumDir,'out','Default')
-OutputDir      = join(DataTree,'sourcebuild')
+OutputDir      = PlatformDirs.SourceBuild
 
 DepotTools_URL = "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 PDFium_URL     = "https://pdfium.googlesource.com/pdfium.git"

--- a/build_pdfium.py
+++ b/build_pdfium.py
@@ -46,7 +46,7 @@ NativeBuildConfig = DefaultConfig.copy()
 NativeBuildConfig += [
 'clang_use_chrome_plugins = false',
 'treat_warnings_as_errors = false',
-'init_stack_vars = false',
+#'init_stack_vars = false',
 ]
 
 PdfiumPatches = [

--- a/build_pdfium.py
+++ b/build_pdfium.py
@@ -22,7 +22,7 @@ PatchDir       = join(SB_Dir,'patches')
 DepotToolsDir  = join(SB_Dir,'depot_tools')
 PDFiumDir      = join(SB_Dir,'pdfium')
 PDFiumBuildDir = join(PDFiumDir,'out','Default')
-OutputDir      = join(SourceTree,'data','sourcebuild')
+OutputDir      = join(DataTree,'sourcebuild')
 
 DepotTools_URL = "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
 PDFium_URL     = "https://pdfium.googlesource.com/pdfium.git"

--- a/data/setup_status.txt
+++ b/data/setup_status.txt
@@ -1,0 +1,1 @@
+PreSetupDone

--- a/data/setup_status.txt
+++ b/data/setup_status.txt
@@ -1,1 +1,1 @@
-PreSetupDone
+InitialState

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,3 @@
 sphinx >= 4.4.0
 sphinx-rtd-theme
 sphinxcontrib-programoutput
-pypdfium2

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@
 
 [metadata]
 name = pypdfium2
-version = attr: pypdfium2._version.V_PYPDFIUM2
 description = Python bindings to PDFium
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,146 @@
 # SPDX-FileCopyrightText: 2022 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-import setup_source
+import sysconfig
+import update_pdfium
 import build_pdfium
+import setup_source
+import setup_darwin_arm64
+import setup_darwin_x64
+import setup_linux_arm32
+import setup_linux_arm64
+import setup_linux_x64
+import setup_windows_arm64
+import setup_windows_x64
+import setup_windows_x86
+import _getdeps as getdeps
+from os.path import join
+from _packaging import SourceTree
 
-sb_argv = [
-    '--getdeps',
-]
+
+StatusFile = join(SourceTree,'.setup_status.txt')
+
+def perform_presetup() -> bool:
+    with open(StatusFile, 'r') as file_handle:
+        content = file_handle.read().strip()
+    if content == 'InitialState':
+        return True
+    elif content == 'PreSetupDone':
+        return False
+    else:
+        raise ValueError( "Invalid content in setup status file: '{}'".format(content) )
+
+
+class PlatformManager:
+    
+    def __init__(self):
+        
+        plat_name = sysconfig.get_platform().lower()
+        for char in ('-', '.'):
+            plat_name = plat_name.replace(char, '_')
+        
+        self.plat_name = plat_name
+    
+    def _is_platform(self, start, end):
+        if self.plat_name.startswith(start):
+            if self.plat_name.endswith(end):
+                return True
+        return False
+    
+    def is_darwin_arm64(self):
+        return self._is_platform('macosx', 'arm64')
+    
+    def is_darwin_x64(self):
+        return self._is_platform('macosx', 'x86_64')
+    
+    def is_linux_arm32(self):
+        return self._is_platform('linux', 'armv7l')
+    
+    def is_linux_arm64(self):
+        return self._is_platform('linux', 'aarch64')
+    
+    def is_linux_x64(self):
+        return self._is_platform('linux', 'x86_64')
+    
+    def is_windows_arm64(self):
+        return self._is_platform('win', 'arm64')
+    
+    def is_windows_x64(self):
+        return self._is_platform('win', 'amd64')
+    
+    def is_windows_x86(self):
+        return self.plat_name.startswith('win32')
+
+
+
+def main():
+    
+    # Since setuptools may run this code multiple times with different commands,
+    # we have a status file to check whether pre-setup tasks have already been done.
+    # If you deliberately wish to re-run them, set the content of `.setup_status.txt`
+    # to `InitialState`.
+    w_presetup = perform_presetup()
+    
+    
+    # function to generate bindings, if doing pre-setup
+    def _make_bindings(platform_str):
+        if w_presetup: update_pdfium.main( ['-p', platform_str] )
+    
+    
+    if w_presetup:
+        
+        # automatically check/install dependencies
+        getdeps.main()
+        
+        # update staus file
+        with open(StatusFile, 'w') as file_handle:
+            file_handle.write("PreSetupDone")
+    
+    
+    # tooling to determine the current platform
+    plat = PlatformManager()
+    
+    # run the corresponding setup code
+    if plat.is_darwin_arm64():
+        _make_bindings('darwin-arm64')
+        setup_darwin_arm64.main()
+    
+    elif plat.is_darwin_x64():
+        _make_bindings('darwin-x64')
+        setup_darwin_x64.main()
+    
+    elif plat.is_linux_arm32():
+        _make_bindings('linux-arm32')
+        setup_linux_arm32.main()
+    
+    elif plat.is_linux_arm64():
+        _make_bindings('linux-arm64')
+        setup_linux_arm64.main()
+    
+    elif plat.is_linux_x64():
+        _make_bindings('linux-x64')
+        setup_linux_x64.main()
+    
+    elif plat.is_windows_arm64():
+        _make_bindings('windows-arm64')
+        setup_windows_arm64.main()
+    
+    elif plat.is_windows_x64():
+        _make_bindings('windows-x64')
+        setup_windows_x64.main()
+    
+    elif plat.is_windows_x86():
+        _make_bindings('windows-x86')
+        setup_windows_x86.main()
+    
+    # Platform without pre-built binaries - trying a regular sourcebuild
+    # In case it does not work, you may want to attempt a native build (`./build_pdfium -p`),
+    # and then write a wheel to `dist/` using `python3 setup_source.py bdist_wheel`
+    else:
+        if w_presetup:
+            build_pdfium.main( build_pdfium.parse_args() )
+        setup_source.main()
+
 
 if __name__ == '__main__':
-    args = build_pdfium.parse_args(sb_argv)
-    build_pdfium.main(args)
-    setup_source.main()
+    main()

--- a/setup.py
+++ b/setup.py
@@ -20,16 +20,7 @@ from os.path import (
     join,
     basename,
 )
-from _setup_base import (
-    Darwin64,
-    DarwinArm64,
-    Linux64,
-    LinuxArm64,
-    LinuxArm32,
-    Windows64,
-    Windows86,
-    WindowsArm64,
-)
+from _setup_base import PlatformDirs
 
 
 StatusFile = join(DataTree,'setup_status.txt')
@@ -114,35 +105,35 @@ def main():
     
     # run the corresponding setup code
     if plat.is_darwin_arm64():
-        _make_bindings(DarwinArm64, w_presetup)
+        _make_bindings(PlatformDirs.DarwinArm64, w_presetup)
         setup_darwin_arm64.main()
     
     elif plat.is_darwin_x64():
-        _make_bindings(Darwin64, w_presetup)
+        _make_bindings(PlatformDirs.Darwin64, w_presetup)
         setup_darwin_x64.main()
     
     elif plat.is_linux_arm32():
-        _make_bindings(LinuxArm32, w_presetup)
+        _make_bindings(PlatformDirs.LinuxArm32, w_presetup)
         setup_linux_arm32.main()
     
     elif plat.is_linux_arm64():
-        _make_bindings(LinuxArm64, w_presetup)
+        _make_bindings(PlatformDirs.LinuxArm64, w_presetup)
         setup_linux_arm64.main()
     
     elif plat.is_linux_x64():
-        _make_bindings(Linux64, w_presetup)
+        _make_bindings(PlatformDirs.Linux64, w_presetup)
         setup_linux_x64.main()
     
     elif plat.is_windows_arm64():
-        _make_bindings(WindowsArm64, w_presetup)
+        _make_bindings(PlatformDirs.WindowsArm64, w_presetup)
         setup_windows_arm64.main()
     
     elif plat.is_windows_x64():
-        _make_bindings(Windows64, w_presetup)
+        _make_bindings(PlatformDirs.Windows64, w_presetup)
         setup_windows_x64.main()
     
     elif plat.is_windows_x86():
-        _make_bindings(Windows86, w_presetup)
+        _make_bindings(PlatformDirs.Windows86, w_presetup)
         setup_windows_x86.main()
     
     # Platform without pre-built binaries - trying a regular sourcebuild

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ import setup_windows_x64
 import setup_windows_x86
 import _getdeps as getdeps
 from _packaging import DataTree
+from _setup_base import PlatformDirs
 from os.path import (
     join,
     basename,
 )
-from _setup_base import PlatformDirs
 
 
 StatusFile = join(DataTree,'setup_status.txt')

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ class PlatformManager:
         return self._is_platform('win', 'amd64')
     
     def is_windows_x86(self):
-        return self.plat_name.startswith('win32')
+        return self._is_platform('win32', '')
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from os.path import (
 
 StatusFile = join(DataTree,'setup_status.txt')
 
-def check_with_presetup() -> bool:
+def check_presetup() -> bool:
     with open(StatusFile, 'r') as file_handle:
         content = file_handle.read().strip()
     if content == 'InitialState':
@@ -89,7 +89,7 @@ def main():
     # we have a status file to check whether pre-setup tasks have already been done.
     # If you deliberately wish to re-run them, set the content of `data/setup_status.txt`
     # to `InitialState`.
-    w_presetup = check_with_presetup()
+    w_presetup = check_presetup()
     
     if w_presetup:
         

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ def main():
     
     # Since setuptools may run this code multiple times with different commands,
     # we have a status file to check whether pre-setup tasks have already been done.
-    # If you deliberately wish to re-run them, set the content of `.setup_status.txt`
+    # If you deliberately wish to re-run them, set the content of `data/setup_status.txt`
     # to `InitialState`.
     w_presetup = perform_presetup()
     

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ import setup_windows_x64
 import setup_windows_x86
 import _getdeps as getdeps
 from os.path import join
-from _packaging import SourceTree
+from _packaging import DataTree
 
 
-StatusFile = join(SourceTree,'.setup_status.txt')
+StatusFile = join(DataTree,'setup_status.txt')
 
 def perform_presetup() -> bool:
     with open(StatusFile, 'r') as file_handle:

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ def main():
         # automatically check/install dependencies
         getdeps.main()
         
-        # update staus file
+        # update status file
         with open(StatusFile, 'w') as file_handle:
             file_handle.write("PreSetupDone")
     

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,8 @@ def main():
     # and then write a wheel to `dist/` using `python3 setup_source.py bdist_wheel`
     else:
         if w_presetup:
-            build_pdfium.main( build_pdfium.parse_args() )
+            args = build_pdfium.parse_args([])
+            build_pdfium.main(args)
         setup_source.main()
 
 

--- a/setup_darwin_arm64.py
+++ b/setup_darwin_arm64.py
@@ -16,7 +16,7 @@ def lib_setup():
     )
 
 def main():
-    return build(lib_setup, DarwinArm64)
+    return build(lib_setup, PlatformDirs.DarwinArm64)
 
 if __name__ == '__main__':
     main()

--- a/setup_darwin_arm64.py
+++ b/setup_darwin_arm64.py
@@ -15,5 +15,8 @@ def lib_setup():
         package_data = {'': ['pdfium.dylib']},
     )
 
+def main():
+    return build(lib_setup, DarwinArm64)
+
 if __name__ == '__main__':
-    build(lib_setup, DarwinArm64)
+    main()

--- a/setup_darwin_arm64.py
+++ b/setup_darwin_arm64.py
@@ -13,6 +13,7 @@ def lib_setup():
     setuptools.setup(
         cmdclass = {'bdist_wheel': bdist},
         package_data = {'': ['pdfium.dylib']},
+        **SetupKws,
     )
 
 def main():

--- a/setup_darwin_x64.py
+++ b/setup_darwin_x64.py
@@ -16,7 +16,7 @@ def lib_setup():
     )
 
 def main():
-    return build(lib_setup, Darwin64)
+    return build(lib_setup, PlatformDirs.Darwin64)
 
 if __name__ == '__main__':
     main()

--- a/setup_darwin_x64.py
+++ b/setup_darwin_x64.py
@@ -15,5 +15,8 @@ def lib_setup():
         package_data = {'': ['pdfium.dylib']},
     )
 
+def main():
+    return build(lib_setup, Darwin64)
+
 if __name__ == '__main__':
-    build(lib_setup, Darwin64)
+    main()

--- a/setup_darwin_x64.py
+++ b/setup_darwin_x64.py
@@ -13,6 +13,7 @@ def lib_setup():
     setuptools.setup(
         cmdclass = {'bdist_wheel': bdist},
         package_data = {'': ['pdfium.dylib']},
+        **SetupKws,
     )
 
 def main():

--- a/setup_linux_arm32.py
+++ b/setup_linux_arm32.py
@@ -15,5 +15,8 @@ def lib_setup():
         package_data = {'': ['pdfium']},
     )
 
+def main():
+    return build(lib_setup, LinuxArm32)
+
 if __name__ == '__main__':
-    build(lib_setup, LinuxArm32)
+    main()

--- a/setup_linux_arm32.py
+++ b/setup_linux_arm32.py
@@ -16,7 +16,7 @@ def lib_setup():
     )
 
 def main():
-    return build(lib_setup, LinuxArm32)
+    return build(lib_setup, PlatformDirs.LinuxArm32)
 
 if __name__ == '__main__':
     main()

--- a/setup_linux_arm32.py
+++ b/setup_linux_arm32.py
@@ -13,6 +13,7 @@ def lib_setup():
     setuptools.setup(
         cmdclass = {'bdist_wheel': bdist},
         package_data = {'': ['pdfium']},
+        **SetupKws,
     )
 
 def main():

--- a/setup_linux_arm64.py
+++ b/setup_linux_arm64.py
@@ -16,7 +16,7 @@ def lib_setup():
     )
 
 def main():
-    return build(lib_setup, LinuxArm64)
+    return build(lib_setup, PlatformDirs.LinuxArm64)
 
 if __name__ == '__main__':
     main()

--- a/setup_linux_arm64.py
+++ b/setup_linux_arm64.py
@@ -15,5 +15,8 @@ def lib_setup():
         package_data = {'': ['pdfium']},
     )
 
+def main():
+    return build(lib_setup, LinuxArm64)
+
 if __name__ == '__main__':
-    build(lib_setup, LinuxArm64)
+    main()

--- a/setup_linux_arm64.py
+++ b/setup_linux_arm64.py
@@ -13,6 +13,7 @@ def lib_setup():
     setuptools.setup(
         cmdclass = {'bdist_wheel': bdist},
         package_data = {'': ['pdfium']},
+        **SetupKws,
     )
 
 def main():

--- a/setup_linux_x64.py
+++ b/setup_linux_x64.py
@@ -15,5 +15,8 @@ def lib_setup():
         package_data = {'': ['pdfium']},
     )
 
+def main():
+    return build(lib_setup, Linux64)
+
 if __name__ == '__main__':
-    build(lib_setup, Linux64)
+    main()

--- a/setup_linux_x64.py
+++ b/setup_linux_x64.py
@@ -16,7 +16,7 @@ def lib_setup():
     )
 
 def main():
-    return build(lib_setup, Linux64)
+    return build(lib_setup, PlatformDirs.Linux64)
 
 if __name__ == '__main__':
     main()

--- a/setup_linux_x64.py
+++ b/setup_linux_x64.py
@@ -13,6 +13,7 @@ def lib_setup():
     setuptools.setup(
         cmdclass = {'bdist_wheel': bdist},
         package_data = {'': ['pdfium']},
+        **SetupKws,
     )
 
 def main():

--- a/setup_sdist.py
+++ b/setup_sdist.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2022 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-import setuptools
+from _setup_base import *
 
 if __name__ == '__main__':
-    setuptools.setup()
+    setuptools.setup(**SetupKws)

--- a/setup_source.py
+++ b/setup_source.py
@@ -18,6 +18,7 @@ def lib_setup(libname):
     setuptools.setup(
         cmdclass = {'bdist_wheel': bdist},
         package_data = {'': [libname]},
+        **SetupKws,
     )
 
 

--- a/setup_source.py
+++ b/setup_source.py
@@ -23,13 +23,13 @@ def lib_setup(libname):
 
 
 def get_binary():
-    libpath = build_pdfium.find_lib(directory=build_pdfium.OutputDir)
+    libpath = build_pdfium.find_lib(directory=PlatformDirs.SourceBuild)
     return os.path.basename(libpath)
 
 
 def main():
     libname = get_binary()
-    build(lambda: lib_setup(libname), build_pdfium.OutputDir)
+    build(lambda: lib_setup(libname), PlatformDirs.SourceBuild)
     binary_path = join(SourceTree, 'src', 'pypdfium2', libname)
 
 

--- a/setup_windows_arm64.py
+++ b/setup_windows_arm64.py
@@ -15,5 +15,8 @@ def lib_setup():
         package_data = {'': ['pdfium.dll']},
     )
 
+def main():
+    return build(lib_setup, WindowsArm64)
+
 if __name__ == '__main__':
-    build(lib_setup, WindowsArm64)
+    main()

--- a/setup_windows_arm64.py
+++ b/setup_windows_arm64.py
@@ -16,7 +16,7 @@ def lib_setup():
     )
 
 def main():
-    return build(lib_setup, WindowsArm64)
+    return build(lib_setup, PlatformDirs.WindowsArm64)
 
 if __name__ == '__main__':
     main()

--- a/setup_windows_arm64.py
+++ b/setup_windows_arm64.py
@@ -13,6 +13,7 @@ def lib_setup():
     setuptools.setup(
         cmdclass = {'bdist_wheel': bdist},
         package_data = {'': ['pdfium.dll']},
+        **SetupKws,
     )
 
 def main():

--- a/setup_windows_x64.py
+++ b/setup_windows_x64.py
@@ -16,5 +16,8 @@ def lib_setup():
         package_data = {'': ['pdfium.dll']},
     )
 
+def main():
+    return build(lib_setup, Windows64)
+
 if __name__ == '__main__':
-    build(lib_setup, Windows64)
+    main()

--- a/setup_windows_x64.py
+++ b/setup_windows_x64.py
@@ -17,7 +17,7 @@ def lib_setup():
     )
 
 def main():
-    return build(lib_setup, Windows64)
+    return build(lib_setup, PlatformDirs.Windows64)
 
 if __name__ == '__main__':
     main()

--- a/setup_windows_x64.py
+++ b/setup_windows_x64.py
@@ -14,6 +14,7 @@ def lib_setup():
     setuptools.setup(
         cmdclass = {'bdist_wheel': bdist},
         package_data = {'': ['pdfium.dll']},
+        **SetupKws,
     )
 
 def main():

--- a/setup_windows_x86.py
+++ b/setup_windows_x86.py
@@ -16,7 +16,7 @@ def lib_setup():
     )
 
 def main():
-    return build(lib_setup, Windows86)
+    return build(lib_setup, PlatformDirs.Windows86)
 
 if __name__ == '__main__':
     main()

--- a/setup_windows_x86.py
+++ b/setup_windows_x86.py
@@ -15,5 +15,8 @@ def lib_setup():
         package_data = {'': ['pdfium.dll']},
     )
 
+def main():
+    return build(lib_setup, Windows86)
+
 if __name__ == '__main__':
-    build(lib_setup, Windows86)
+    main()

--- a/setup_windows_x86.py
+++ b/setup_windows_x86.py
@@ -13,6 +13,7 @@ def lib_setup():
     setuptools.setup(
         cmdclass = {'bdist_wheel': bdist},
         package_data = {'': ['pdfium.dll']},
+        **SetupKws,
     )
 
 def main():

--- a/src/pypdfium2/_version.py
+++ b/src/pypdfium2/_version.py
@@ -10,5 +10,4 @@ V_PYPDFIUM2 = "{}.{}.{}".format(V_MAJOR, V_MINOR, V_PATCH)  #: PyPDFium2 version
 if V_BETA is not None:
     V_PYPDFIUM2 += "b{}".format(V_BETA)
 
-V_LIBPDFIUM = 4849
-""" PDFium library version integer (git tag) """
+V_LIBPDFIUM = 4849  #: PDFium library version integer (git tag)

--- a/update_pdfium.py
+++ b/update_pdfium.py
@@ -31,11 +31,11 @@ from _setup_base import (
 )
 from _packaging import (
     SourceTree,
+    DataTree,
     postprocess_bindings,
 )
 
 VersionFile  = join(SourceTree,'src','pypdfium2','_version.py')
-DataTree     = join(SourceTree,'data')
 ReleaseURL   = 'https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F'
 ReleaseExtension = 'tgz'
 ReleaseFiles = {

--- a/update_pdfium.py
+++ b/update_pdfium.py
@@ -5,6 +5,7 @@
 # Download the PDFium binaries and generate ctypes bindings
 
 import os
+import sys
 from os.path import (
     join,
     dirname,
@@ -211,7 +212,7 @@ def generate_bindings(archives):
         shutil.rmtree(build_dir)
 
 
-def parse_args():
+def parse_args(argv):
     parser = argparse.ArgumentParser(
         description = "Download pre-built PDFium packages and generate the bindings,",
     )
@@ -220,7 +221,7 @@ def parse_args():
         metavar = 'P',
         nargs = '*',
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def get_download_files(args):
@@ -249,9 +250,9 @@ def get_download_files(args):
     return download_files
 
 
-def main():
+def main(argv=sys.argv[1:]):
     
-    args = parse_args()
+    args = parse_args(argv)
     download_files = get_download_files(args)
     
     latest_version = get_latest_version()

--- a/update_pdfium.py
+++ b/update_pdfium.py
@@ -19,19 +19,9 @@ import traceback
 import subprocess
 from urllib import request
 from concurrent.futures import ThreadPoolExecutor
-from _setup_base import (
-    Darwin64,
-    DarwinArm64,
-    Linux64,
-    LinuxArm64,
-    LinuxArm32,
-    Windows64,
-    Windows86,
-    WindowsArm64,
-)
+from _setup_base import PlatformDirs
 from _packaging import (
     SourceTree,
-    DataTree,
     postprocess_bindings,
 )
 
@@ -39,14 +29,14 @@ VersionFile  = join(SourceTree,'src','pypdfium2','_version.py')
 ReleaseURL   = 'https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F'
 ReleaseExtension = 'tgz'
 ReleaseFiles = {
-    Darwin64     : 'pdfium-mac-x64',
-    DarwinArm64  : 'pdfium-mac-arm64',
-    Linux64      : 'pdfium-linux-x64',
-    LinuxArm64   : 'pdfium-linux-arm64',
-    LinuxArm32   : 'pdfium-linux-arm',
-    Windows64    : 'pdfium-win-x64',
-    Windows86    : 'pdfium-win-x86',
-    WindowsArm64 : 'pdfium-win-arm64',
+    PlatformDirs.Darwin64     : 'pdfium-mac-x64',
+    PlatformDirs.DarwinArm64  : 'pdfium-mac-arm64',
+    PlatformDirs.Linux64      : 'pdfium-linux-x64',
+    PlatformDirs.LinuxArm64   : 'pdfium-linux-arm64',
+    PlatformDirs.LinuxArm32   : 'pdfium-linux-arm',
+    PlatformDirs.Windows64    : 'pdfium-win-x64',
+    PlatformDirs.Windows86    : 'pdfium-win-x86',
+    PlatformDirs.WindowsArm64 : 'pdfium-win-arm64',
 }
 
 

--- a/utilities/clean.sh
+++ b/utilities/clean.sh
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: 2022 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-rm -r dist
-rm -r data/*
-touch data/.gitkeep
 rm -r src/pypdfium2.egg-info/
 rm -r __pycache__
 rm -r src/pypdfium2/__pycache__
+rm -r dist
+rm -r data/*
+touch data/.gitkeep
+echo "InitialState" > data/setup_status.txt

--- a/utilities/release.sh
+++ b/utilities/release.sh
@@ -2,13 +2,21 @@
 # SPDX-FileCopyrightText: 2022 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+# clean up
+bash utilities/clean.sh
+
 # check for unused imports
 importchecker src/
 importchecker tests/
 for pyfile in *.py; do importchecker "$pyfile"; done
 
-bash utilities/clean.sh
+# check for possible spelling mistakes
+codespell --skip="./sourcebuild,./docs/build/html,./data,./.git,__pycache__,.mypy_cache,"
+
+# download binaries and create the wheels
 python3 update_pdfium.py
 bash utilities/setup_all.sh
+
+# ensure validity of the generated wheels
 twine check dist/*
 check-wheel-contents dist/*.whl

--- a/utilities/release.sh
+++ b/utilities/release.sh
@@ -11,7 +11,7 @@ importchecker tests/
 for pyfile in *.py; do importchecker "$pyfile"; done
 
 # check for possible spelling mistakes
-codespell --skip="./sourcebuild,./docs/build/html,./data,./.git,__pycache__,.mypy_cache,"
+codespell --skip="./sourcebuild,./docs/build,./data,./.git,__pycache__,.mypy_cache,"
 
 # download binaries and create the wheels
 python3 update_pdfium.py


### PR DESCRIPTION
Previously, running `setup.py` always triggered a source build, on behalf of platforms where no wheel is available.
This MR changes the setup strategy in a fundamental way. Now `setup.py` determines the current platform and uses pre-built binaries if available, with source build only as fallback. This is quite advantageous:
* Users who wish to install PyPDFium2 from git main can do so by just downloading the repository and running
  `pip3 install . -v`, as this now won't trigger a time-consuming and uncertain source build anymore unless it's really necessary.
* Re-installing PyPDFium2 during development is simplified a lot.
* ReadTheDocs can now be configured in a saner way. We are no longer bound to the current release on PyPI, but can just check the option `Install Project` and remove `pypdfium2` from `docs/requirements.txt`.

On the way of restructuring the setup, I also addressed another issue that I was concerned about since a longer time:
The setup code was ran twice, because pip has to execute the file repeatedly with different commands. This can be quite a slowdown if a lot of tasks have to be done, such as dependency installation and all the build commands. Luckily, PDFium's build system has been intelligent enough to detect that it doesn't need to recompile with the second run.
I now fixed this using a text file `data/setup_status.txt` to track the current setup state. By default, it contains the string `InitialState`. On the first setup run, all tasks that only need to be done once are performed, and status is updated to `PreSetupDone`. In the following run, `PreSetupDone` is detected and the tasks are skipped.