### PR TITLE
Experimental direct RGB(A) rendering

### DIFF
--- a/src/pypdfium2/_helpers/_utils.py
+++ b/src/pypdfium2/_helpers/_utils.py
@@ -4,9 +4,9 @@
 import pypdfium2._pypdfium as pdfium
 
 
-def colour_tohex(r, g, b, a=255):
+def colour_tohex(r, g, b, a=255, greyscale=False):
     """
-    Convert an RGBA colour specified by four integers ranging from 0 to 255 to a single ARGB32 value.
+    Convert an RGBA colour specified by four integers ranging from 0 to 255 to a single value.
     
     Returns:
         (int, bool): The colour value, and a boolean signifying if an alpha channel is needed.
@@ -16,7 +16,10 @@ def colour_tohex(r, g, b, a=255):
     if a == 255:
         use_alpha = False
     
-    colours = (a, r, g, b)
+    if greyscale and not use_alpha:
+        colours = (a, r, g, b)
+    else:
+        colours = (a, b, g, r)
     for col in colours:
         assert 0 <= col <= 255
     

--- a/tests/helpers/test_renderer.py
+++ b/tests/helpers/test_renderer.py
@@ -129,19 +129,20 @@ def test_render_page_greyscale(sample_page):
 
 
 @pytest.mark.parametrize(
-    "colour",
+    ["name", "colour"],
     [
-        (255, 255, 255, 255),
-        (60,  70,  80,  100),
-        (255, 255, 255),
-        (0,   255, 255),
-        (255, 0,   255),
-        (255, 255, 0  ),
+        ("1", (255, 255, 255, 255)),
+        ("2", (60,  70,  80,  100)),
+        ("3", (255, 255, 255)),
+        ("4", (0,   255, 255)),
+        ("5", (255, 0,   255)),
+        ("6", (255, 255, 0  )),
     ]
 )
-def test_render_page_bgcolour(colour, sample_page):
+def test_render_page_bgcolour(name, colour, sample_page):
     
     pil_image = sample_page.render_topil(colour=colour, scale=0.5)
+    pil_image.save( join(OutputDir, "bgcolour_%s.png" % name) )
     assert pil_image.size == (298, 421)
     
     px_colour = colour
@@ -160,14 +161,15 @@ def test_render_page_tobytes(sample_page):
     bytedata, cl_format, size = sample_page.render_tobytes(scale=0.5)
     
     assert isinstance(bytedata, bytes)
-    assert cl_format == "BGR"
+    assert cl_format == "RGB"
     assert size == (298, 421)
     assert len(bytedata) == size[0] * size[1] * len(cl_format)
     
-    pil_image = PIL.Image.frombytes("RGB", size, bytedata, "raw", "BGR")
+    pil_image = PIL.Image.frombytes("RGB", size, bytedata, "raw", cl_format)
     assert pil_image.mode == "RGB"
     assert pil_image.size == (298, 421)
     assert isinstance(pil_image, PIL.Image.Image)
+    pil_image.save( join(OutputDir, "render_bytes.jpg") )
     pil_image.close()
 
 

--- a/tests/helpers/test_renderer.py
+++ b/tests/helpers/test_renderer.py
@@ -52,7 +52,7 @@ def test_render_page_transform(sample_page, name, crop, scale, rotation):
         scale = scale,
         rotation = rotation,
     )
-    pil_image.save( join(OutputDir, "%s.jpg" % name) )
+    pil_image.save( join(OutputDir, "%s.png" % name) )
     assert pil_image.mode == "RGB"
     
     c_left, c_bottom, c_right, c_top = [math.ceil(c*scale) for c in crop]
@@ -169,7 +169,7 @@ def test_render_page_tobytes(sample_page):
     assert pil_image.mode == "RGB"
     assert pil_image.size == (298, 421)
     assert isinstance(pil_image, PIL.Image.Image)
-    pil_image.save( join(OutputDir, "render_bytes.jpg") )
+    pil_image.save( join(OutputDir, "render_bytes.png") )
     pil_image.close()
 
 

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -35,18 +35,19 @@ def test_get_colourformat(use_alpha, greyscale, cl_src, cl_dest, cl_const):
 
 
 @pytest.mark.parametrize(
-    ["values", "cl_value", "use_alpha"],
+    ["values", "cl_abgr", "cl_argb", "use_alpha"],
     [
-        ((255, 255, 255),      0xFFFFFFFF, False),
-        ((255, 255, 255, 255), 0xFFFFFFFF, False),
-        ((0,   255, 255, 255), 0xFF00FFFF, False),
-        ((255, 0,   255, 255), 0xFFFF00FF, False),
-        ((255, 255, 0,   255), 0xFFFFFF00, False),
-        ((255, 255, 255, 0  ), 0x00FFFFFF, True ),
+        ((255, 255, 255),      0xFFFFFFFF, 0xFFFFFFFF, False),
+        ((255, 255, 255, 255), 0xFFFFFFFF, 0xFFFFFFFF, False),
+        ((255, 255, 255, 0  ), 0x00FFFFFF, 0x00FFFFFF, True ),
+        ((0,   255, 255, 255), 0xFFFFFF00, 0xFF00FFFF, False),
+        ((255, 0,   255, 255), 0xFFFF00FF, 0xFFFF00FF, False),
+        ((255, 255, 0,   255), 0xFF00FFFF, 0xFFFFFF00, False),
     ]
 )
-def test_colour_tohex(values, cl_value, use_alpha):
-    assert colour_tohex(*values) == (cl_value, use_alpha)
+def test_colour_tohex(values, cl_abgr, cl_argb, use_alpha):
+    assert colour_tohex(*values, greyscale=False) == (cl_abgr, use_alpha)
+    assert colour_tohex(*values, greyscale=True)  == (cl_argb, use_alpha)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This change would make PDFium render RGB(A) directly, instead of BGR(A), using the `pdfium.FPDF_REVERSE_BYTE_ORDER` flag. Might be advantageous as RGB(A) is more common, so callers who directly work with the bytes could use them as-is and would not need to change the byte order. Perhaps it might also make constructing the PIL image slightly faster (need to check).

However, this adds additional complexity: The aforementioned flag doesn't work well with `FPDFBitmap_Gray`, as some parts are missing in the result (probably due to a PDFium bug). It doesn't really matter because that's only one channel anyway, but it means we need to handle background colour separately. RGB(A) bitmaps would need ABGR, and L bitmaps ARGB, then. Rather confusing.