### PR TITLE
Improve opening

### DIFF
--- a/src/pypdfium2/_helpers/_opener.py
+++ b/src/pypdfium2/_helpers/_opener.py
@@ -43,7 +43,7 @@ class ReaderClass:
         return 1
 
 
-def _is_buffer(maybe_buffer):
+def is_input_buffer(maybe_buffer):
     if all( callable(getattr(maybe_buffer, a, None)) for a in ('seek', 'tell', 'readinto') ):
         return True
     else:
@@ -91,7 +91,7 @@ def open_pdf(input_data, password=None, autoclose=False):
         pdf, ld_data = open_pdf_file(input_data, password), None
     elif isinstance(input_data, bytes):
         pdf, ld_data = open_pdf_bytes(input_data, password)
-    elif _is_buffer(input_data):
+    elif is_input_buffer(input_data):
         pdf, ld_data = open_pdf_buffer(input_data, password, autoclose)
     else:
         raise TypeError("The input must be a file path string, bytes, or a byte buffer, but '%s' was given." % type(input_data).__name__)

--- a/src/pypdfium2/_helpers/_opener.py
+++ b/src/pypdfium2/_helpers/_opener.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 import ctypes
-from os.path import abspath, expanduser, isfile
 import pypdfium2._pypdfium as pdfium
 from pypdfium2._helpers.misc import raise_error
 
@@ -50,13 +49,6 @@ def is_input_buffer(maybe_buffer):
         return False
 
 
-def open_pdf_file(filepath, password=None):
-    filepath = abspath( expanduser(filepath) )
-    if not isfile(filepath):
-        raise FileNotFoundError("File does not exist: '%s'" % filepath)
-    return pdfium.FPDF_LoadDocument(filepath, password)
-
-
 def open_pdf_buffer(buffer, password=None, autoclose=False):
     
     buffer.seek(0, 2)
@@ -87,8 +79,9 @@ def open_pdf_bytes(bytedata, password=None):
 
 def open_pdf(input_data, password=None, autoclose=False):
     
+    ld_data = None
     if isinstance(input_data, str):
-        pdf, ld_data = open_pdf_file(input_data, password), None
+        pdf = pdfium.FPDF_LoadDocument(input_data, password)
     elif isinstance(input_data, bytes):
         pdf, ld_data = open_pdf_bytes(input_data, password)
     elif is_input_buffer(input_data):

--- a/src/pypdfium2/_helpers/document.py
+++ b/src/pypdfium2/_helpers/document.py
@@ -44,7 +44,7 @@ class PdfDocument:
             A password to unlock the PDF, if encrypted.
         autoclose (bool):
             If set to :data:`True` and a byte buffer was provided as input, :meth:`.close` will not only close the PDFium document, but also the input source.
-        file_strategy (FileAccess):
+        file_access (FileAccess):
             Define how files shall be opened internally. This parameter is ignored if *input_data* is not a file path.
     """
     
@@ -53,7 +53,7 @@ class PdfDocument:
             input_data,
             password = None,
             autoclose = False,
-            file_strategy = FileAccess.NATIVE,
+            file_access = FileAccess.NATIVE,
         ):
         
         self._orig_input = input_data
@@ -63,7 +63,7 @@ class PdfDocument:
         
         self._password = password
         self._autoclose = autoclose
-        self._file_strategy = file_strategy
+        self._file_access = file_access
         
         if isinstance(self._orig_input, str):
             
@@ -71,17 +71,17 @@ class PdfDocument:
             if not os.path.isfile(self._orig_input):
                 raise FileNotFoundError("File does not exist: '%s'" % self._orig_input)
             
-            if self._file_strategy is FileAccess.NATIVE:
+            if self._file_access is FileAccess.NATIVE:
                 pass
-            elif self._file_strategy is FileAccess.BUFFER:
+            elif self._file_access is FileAccess.BUFFER:
                 self._actual_input = open(self._orig_input, "rb")
                 self._autoclose = True
-            elif self._file_strategy is FileAccess.BYTES:
+            elif self._file_access is FileAccess.BYTES:
                 buf = open(self._orig_input, "rb")
                 self._actual_input = buf.read()
                 buf.close()
             else:
-                raise ValueError("An invalid file access strategy was given: '%s'" % self._file_strategy)
+                raise ValueError("An invalid file access strategy was given: '%s'" % self._file_access)
         
         if isinstance(self._actual_input, pdfium.FPDF_DOCUMENT):
             self._pdf = self._actual_input
@@ -321,11 +321,11 @@ class PdfDocument:
     
     
     @classmethod
-    def _process_page(cls, index, renderer_name, input_data, password, file_strategy, **kwargs):
+    def _process_page(cls, index, renderer_name, input_data, password, file_access, **kwargs):
         pdf = cls(
             input_data,
             password = password,
-            file_strategy = file_strategy,
+            file_access = file_access,
         )
         page = pdf.get_page(index)
         result = getattr(page, "render_to"+renderer_name)(**kwargs)
@@ -381,7 +381,7 @@ class PdfDocument:
             renderer_name = renderer_name,
             input_data = self._rendering_input,
             password = self._password,
-            file_strategy = self._file_strategy,
+            file_access = self._file_access,
             **kwargs
         )
         

--- a/src/pypdfium2/_helpers/document.py
+++ b/src/pypdfium2/_helpers/document.py
@@ -310,8 +310,9 @@ class PdfDocument:
     
     def update_rendering_input(self):
         """
-        Update the rendering input sources to the document's current state by saving to bytes and setting the result as new input.
-        If you modified the document, you may want to call this method before doing concurrent rendering.
+        Update the input sources for concurrent rendering to the document's current state
+        by saving to bytes and setting the result as new input.
+        If you modified the document, you may want to call this method before :meth:`._render_base`.
         """
         buffer = io.BytesIO()
         self.save(buffer)

--- a/src/pypdfium2/_helpers/document.py
+++ b/src/pypdfium2/_helpers/document.py
@@ -3,6 +3,7 @@
 
 import io
 import os
+import os.path
 import ctypes
 import logging
 import functools
@@ -65,6 +66,11 @@ class PdfDocument:
         self._file_strategy = file_strategy
         
         if isinstance(self._orig_input, str):
+            
+            self._orig_input = os.path.abspath( os.path.expanduser(self._orig_input) )
+            if not os.path.isfile(self._orig_input):
+                raise FileNotFoundError("File does not exist: '%s'" % self._orig_input)
+            
             if self._file_strategy is FileAccess.NATIVE:
                 pass
             elif self._file_strategy is FileAccess.BUFFER:
@@ -75,7 +81,7 @@ class PdfDocument:
                 self._actual_input = buf.read()
                 buf.close()
             else:
-                raise ValueError("An invalid file access strategy was given: %s" % self._file_strategy)
+                raise ValueError("An invalid file access strategy was given: '%s'" % self._file_strategy)
         
         if isinstance(self._actual_input, pdfium.FPDF_DOCUMENT):
             self._pdf = self._actual_input

--- a/src/pypdfium2/_helpers/misc.py
+++ b/src/pypdfium2/_helpers/misc.py
@@ -13,6 +13,13 @@ class OptimiseMode (enum.Enum):
     PRINTING = 2     #: Optimise for printing.
 
 
+class FileAccess (enum.Enum):
+    """ Different ways how files can be loaded. """
+    NATIVE = 0  #: :func:`.FPDF_LoadDocument`: Let PDFium open the file in C/C++.
+    BUFFER = 1  #: :func:`.FPDF_LoadCustomDocument`: Acquire a Python file buffer that is read incrementally by callback function.
+    BYTES  = 2  #: :func:`.FPDF_LoadMemDocument`: Read the whole file and pass its data to PDFium at once.
+
+
 class OutlineItem:
     """
     Class to store information about an entry in the table of contents ("bookmark").

--- a/src/pypdfium2/_helpers/misc.py
+++ b/src/pypdfium2/_helpers/misc.py
@@ -6,18 +6,18 @@ import pypdfium2._pypdfium as pdfium
 from pypdfium2._helpers._utils import ErrorMapping
 
 
+class FileAccess (enum.Enum):
+    """ Different ways how files can be loaded. """
+    NATIVE = 0  #: :func:`.FPDF_LoadDocument` - Let PDFium open the file in C/C++.
+    BUFFER = 1  #: :func:`.FPDF_LoadCustomDocument` - Acquire a Python file buffer that is read incrementally by callback function.
+    BYTES  = 2  #: :func:`.FPDF_LoadMemDocument` - Read the whole file into memory and pass the data to PDFium at once.
+
+
 class OptimiseMode (enum.Enum):
     """ Modes defining how page rendering shall be optimised. """
     NONE = 0         #: No optimisation.
     LCD_DISPLAY = 1  #: Optimise for LCD displays (via subpixel rendering).
     PRINTING = 2     #: Optimise for printing.
-
-
-class FileAccess (enum.Enum):
-    """ Different ways how files can be loaded. """
-    NATIVE = 0  #: :func:`.FPDF_LoadDocument`: Let PDFium open the file in C/C++.
-    BUFFER = 1  #: :func:`.FPDF_LoadCustomDocument`: Acquire a Python file buffer that is read incrementally by callback function.
-    BYTES  = 2  #: :func:`.FPDF_LoadMemDocument`: Read the whole file and pass its data to PDFium at once.
 
 
 class OutlineItem:

--- a/tests/helpers/test_opener.py
+++ b/tests/helpers/test_opener.py
@@ -34,7 +34,7 @@ def _check_render(pdf):
 @pytest.fixture
 def open_filepath_native():
     pdf = pdfium.PdfDocument(TestFiles.render)
-    assert pdf._file_strategy is pdfium.FileAccess.NATIVE
+    assert pdf._file_access is pdfium.FileAccess.NATIVE
     _check_general(pdf)
     yield _check_render(pdf)
     pdf.close()
@@ -91,7 +91,7 @@ def test_open_buffer_autoclose():
 
 def test_open_filepath_buffer():
     
-    pdf = pdfium.PdfDocument(TestFiles.render, file_strategy=pdfium.FileAccess.BUFFER)
+    pdf = pdfium.PdfDocument(TestFiles.render, file_access=pdfium.FileAccess.BUFFER)
     
     assert pdf._orig_input == TestFiles.render
     assert isinstance(pdf._actual_input, io.BufferedReader)
@@ -104,7 +104,7 @@ def test_open_filepath_buffer():
 
 def test_open_filepath_bytes():
     
-    pdf = pdfium.PdfDocument(TestFiles.render, file_strategy=pdfium.FileAccess.BYTES)
+    pdf = pdfium.PdfDocument(TestFiles.render, file_access=pdfium.FileAccess.BYTES)
     
     assert pdf._orig_input == TestFiles.render
     assert isinstance(pdf._actual_input, bytes)
@@ -170,9 +170,9 @@ def test_open_invalid():
     with pytest.raises(FileNotFoundError, match=re.escape("File does not exist: '%s'" % abspath("invalid/path"))):
         pdf = pdfium.PdfDocument("invalid/path")
     with pytest.raises(FileNotFoundError, match=re.escape("File does not exist: '%s'" % abspath("invalid/path"))):
-        pdf = pdfium.PdfDocument("invalid/path", file_strategy=pdfium.FileAccess.BUFFER)
+        pdf = pdfium.PdfDocument("invalid/path", file_access=pdfium.FileAccess.BUFFER)
     with pytest.raises(ValueError, match=re.escape("An invalid file access strategy was given: 'abcd'")):
-        pdf = pdfium.PdfDocument(TestFiles.empty, file_strategy="abcd")
+        pdf = pdfium.PdfDocument(TestFiles.empty, file_access="abcd")
 
 
 def test_hierarchy():

--- a/tests/helpers/test_opener.py
+++ b/tests/helpers/test_opener.py
@@ -9,7 +9,7 @@ import pytest
 import PIL.Image
 from os.path import join, abspath
 import pypdfium2 as pdfium
-from ..conftest import TestFiles, ExpRenderPixels, get_members
+from ..conftest import TestFiles, ExpRenderPixels
 
 
 def _check_general(pdf, n_pages=1):

--- a/tests/helpers/test_renderer.py
+++ b/tests/helpers/test_renderer.py
@@ -171,68 +171,6 @@ def test_render_page_tobytes(sample_page):
     pil_image.close()
 
 
-@pytest.fixture
-def render_pdf_topil(multipage_doc):
-    
-    renderer = multipage_doc.render_topil(
-        scale=0.5, greyscale=True,
-    )
-    imgs = []
-    
-    for image in renderer:
-        assert isinstance(image, PIL.Image.Image)
-        assert image.mode == "L"
-        imgs.append(image)
-    
-    assert len(imgs) == 3
-    yield imgs
-    [image.close() for image in imgs]
-
-
-@pytest.fixture
-def render_pdf_tobytes(multipage_doc):
-    
-    renderer = multipage_doc.render_tobytes(
-        scale=0.5, greyscale=True,
-    )
-    imgs = []
-    
-    for imgdata, cl_format, size in renderer:
-        assert cl_format == "L"
-        assert isinstance(imgdata, bytes)
-        assert len(imgdata) == size[0] * size[1] * len(cl_format)
-        pil_image = PIL.Image.frombytes("L", size, imgdata, "raw", "L")
-        imgs.append(pil_image)
-    
-    assert len(imgs) == 3
-    yield imgs
-    [image.close() for image in imgs]
-
-
-def test_render_pdf(render_pdf_topil, render_pdf_tobytes):
-    for image_a, image_b in zip(render_pdf_topil, render_pdf_tobytes):
-        assert image_a == image_b
-
-
-def test_render_pdf_new(caplog):
-    
-    pdf = pdfium.PdfDocument.new()
-    page = pdf.new_page(50, 100)
-    
-    with caplog.at_level(logging.WARNING):
-        renderer = pdf.render_topil()
-        image = next(renderer)
-    
-    warning = "Cannot perform concurrent processing without input sources - saving the document implicitly to get picklable data."
-    assert warning in caplog.text
-    
-    assert isinstance(image, PIL.Image.Image)
-    assert image.mode == "RGB"
-    assert image.size == (50, 100)
-    
-    [g.close() for g in (image, page, pdf)]
-
-
 def test_render_page_optimisation(sample_page):
     
     modes = get_members(pdfium.OptimiseMode)
@@ -259,3 +197,81 @@ def test_render_page_noantialias(sample_page):
     )
     assert isinstance(pil_image, PIL.Image.Image)
     pil_image.close()
+
+
+@pytest.fixture
+def render_pdffile_topil(multipage_doc):
+    
+    renderer = multipage_doc.render_topil(
+        scale=0.5, greyscale=True,
+    )
+    imgs = []
+    
+    for image in renderer:
+        assert isinstance(image, PIL.Image.Image)
+        assert image.mode == "L"
+        imgs.append(image)
+    
+    assert len(imgs) == 3
+    yield imgs
+    [image.close() for image in imgs]
+
+
+@pytest.fixture
+def render_pdffile_tobytes(multipage_doc):
+    
+    renderer = multipage_doc.render_tobytes(
+        scale=0.5, greyscale=True,
+    )
+    imgs = []
+    
+    for imgdata, cl_format, size in renderer:
+        assert cl_format == "L"
+        assert isinstance(imgdata, bytes)
+        assert len(imgdata) == size[0] * size[1] * len(cl_format)
+        pil_image = PIL.Image.frombytes("L", size, imgdata, "raw", "L")
+        imgs.append(pil_image)
+    
+    assert len(imgs) == 3
+    yield imgs
+    [image.close() for image in imgs]
+
+
+def test_render_pdffile(render_pdf_topil, render_pdf_tobytes):
+    for image_a, image_b in zip(render_pdf_topil, render_pdf_tobytes):
+        assert image_a == image_b
+
+
+def test_render_pdf_new(caplog):
+    
+    pdf = pdfium.PdfDocument.new()
+    page = pdf.new_page(50, 100)
+    
+    with caplog.at_level(logging.WARNING):
+        renderer = pdf.render_topil()
+        image = next(renderer)
+    
+    warning = "Cannot perform concurrent processing without input sources - saving the document implicitly to get picklable data."
+    assert warning in caplog.text
+    
+    assert isinstance(image, PIL.Image.Image)
+    assert image.mode == "RGB"
+    assert image.size == (50, 100)
+    
+    [g.close() for g in (image, page, pdf)]
+
+
+def test_render_pdfbuffer():
+    pass
+
+
+def test_render_pdfbytes():
+    pass
+
+
+def test_render_pdffile_asbuffer():
+    pass
+
+
+def test_render_pdffile_asbytes():
+    pass


### PR DESCRIPTION
The previous way of opening had issues with rendering integration: If a byte buffer is given as input, it can't be used concurrently. We can, however, acquire multiple byte buffers for the same file.

As we always want to be able to open files in any way we like, the different access strategies need to be implemented internally in `PdfDocument`.

Therefore, this patch adds a `FileAccess` enum and three different input slots: `self._orig_input`, `self._actual_input`, and `self._rendering_input`.
* `self._orig_input` is basically the original input provided by the caller (except filepaths, which are made absolute).
* `self._actual_input` at first refers to the same object as `self._orig_input`. As the different file access strategies are taken
into account for string input, `self._actual_input` may be substituted accordingly.
* `self._rendering_input` are the sources that will be used for rendering, and they are `None` at first.
  When the rendering method is called, it selects its input source based on `self._orig_input`. Document handles are saved implicitly, byte buffers are read into memory. Other input is taken as-is. If `self._rendering_input` is set already, it will be re-used and no input selection done.
  The renderer then passes the requested file access strategy (`self._file_strategy`) when initialising document objects, thereby achieving the possibility to use any available PDFium opening function for file input.