### PR TITLE
Move form environment from page rendering to document level

### DIFF
--- a/src/pypdfium2/_helpers/document.py
+++ b/src/pypdfium2/_helpers/document.py
@@ -79,6 +79,7 @@ class PdfDocument:
         self._rendering_input = None
         self._ld_data = None
         self._form_env = None
+        self._form_info = None
         
         self._password = password
         self._file_access = file_access
@@ -145,8 +146,8 @@ class PdfDocument:
         This function shall be called when finished working with the object.
         """
         if self._form_env is not None:
-            print(self._form_env)
-            pdfium.FPDFDOC_ExitFormFillEnvironment(self._form_env)  # this call segfaults
+            pdfium.FPDFDOC_ExitFormFillEnvironment(self._form_env)
+            id(self._form_info)
         pdfium.FPDF_CloseDocument(self.raw)
         if self._ld_data is not None:
             self._ld_data.close()
@@ -164,8 +165,9 @@ class PdfDocument:
             FPDF_FORMHANDLE:
         """
         if self._form_env is None:
-            form_info = pdfium.FPDF_FORMFILLINFO(1)
-            self._form_env = pdfium.FPDFDOC_InitFormFillEnvironment(self.raw, form_info)
+            self._form_info = pdfium.FPDF_FORMFILLINFO()
+            self._form_info.version = 2
+            self._form_env = pdfium.FPDFDOC_InitFormFillEnvironment(self.raw, self._form_info)
         return self._form_env
     
     

--- a/src/pypdfium2/_helpers/document.py
+++ b/src/pypdfium2/_helpers/document.py
@@ -79,7 +79,7 @@ class PdfDocument:
         self._rendering_input = None
         self._ld_data = None
         self._form_env = None
-        self._form_info = None
+        self._form_config = None
         
         self._password = password
         self._file_access = file_access
@@ -147,7 +147,7 @@ class PdfDocument:
         """
         if self._form_env is not None:
             pdfium.FPDFDOC_ExitFormFillEnvironment(self._form_env)
-            id(self._form_info)
+            id(self._form_config)
         pdfium.FPDF_CloseDocument(self.raw)
         if self._ld_data is not None:
             self._ld_data.close()
@@ -165,9 +165,9 @@ class PdfDocument:
             FPDF_FORMHANDLE:
         """
         if self._form_env is None:
-            self._form_info = pdfium.FPDF_FORMFILLINFO()
-            self._form_info.version = 2
-            self._form_env = pdfium.FPDFDOC_InitFormFillEnvironment(self.raw, self._form_info)
+            self._form_config = pdfium.FPDF_FORMFILLINFO()
+            self._form_config.version = 2
+            self._form_env = pdfium.FPDFDOC_InitFormFillEnvironment(self.raw, self._form_config)
         return self._form_env
     
     

--- a/src/pypdfium2/_helpers/page.py
+++ b/src/pypdfium2/_helpers/page.py
@@ -422,11 +422,8 @@ class PdfPage:
             pdfium.FPDF_RenderPage_Close(self.raw)
         
         if draw_forms:
-            form_info = pdfium.FPDF_FORMFILLINFO()
-            form_info.version = 1
-            form_env = pdfium.FPDFDOC_InitFormFillEnvironment(self.pdf.raw, form_info)
+            form_env = self.pdf.init_formenv()
             pdfium.FPDF_FFLDraw(form_env, *render_args)
-            pdfium.FPDFDOC_ExitFormFillEnvironment(form_env)
         
         return buffer, cl_string, (width, height)
     


### PR DESCRIPTION
Initially troubled by a segmentation fault, which appears to have been caused be the (undocumented) requirement that the `FPDF_FORMFILLINFO` object needs to stay alive until the exit function is called.