### PR TITLE
readme (example comment): Fix order of tuple returned by searcher.get_next()

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Here are some examples of using the support model API.
   
   # Locate text on the page
   searcher = textpage.search("something", match_case=False, match_whole_word=False)
-  # This will be a list of bounding boxes of the form (left, right, bottom, top)
+  # This will be a list of bounding boxes of the form (left, bottom, right, top)
   first_occurrence = searcher.get_next()
   ```
 


### PR DESCRIPTION
It incorrectly stated that it returns (left, right, bottom, top) tuples. Changed to (left, bottom, right, top).