### PR TITLE
Fix crop box parameter order in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Here are some examples of using the support model API.
       pdfium.BitmapConv.pil_image,
       scale = 1,                           # 72dpi resolution
       rotation = 0,                        # no additional rotation
-      crop = (0, 0, 0, 0),                 # no crop (form: left, right, bottom, top)
+      crop = (0, 0, 0, 0),                 # no crop (form: left, bottom, right, top)
       greyscale = False,                   # coloured output
       fill_colour = (255, 255, 255, 255),  # fill bitmap with white background before rendering (form: RGBA)
       colour_scheme = None,                # no custom colour scheme


### PR DESCRIPTION
The order should be (left, bottom, right, top) as in 

https://github.com/pypdfium2-team/pypdfium2/blob/604c582cafd41e5d8904145076d738558bf1c445/src/pypdfium2/_cli/render.py#L99-L104

and 

https://github.com/pypdfium2-team/pypdfium2/blob/604c582cafd41e5d8904145076d738558bf1c445/src/pypdfium2/_helpers/page.py#L418-L420