### PR TITLE
POC patch to handle mmap as ctypes array

### DIFF
--- a/src/pypdfium2/internal/utils.py
+++ b/src/pypdfium2/internal/utils.py
@@ -42,6 +42,8 @@ def is_buffer(buf, spec="r"):
 
 class _buffer_reader:
     
+    # NOTE the memmove code passage is not covered if we handle mmap as ctypes array
+    
     def __init__(self, buffer):
         self.buffer = buffer
         self._fill = self._readinto if hasattr(self.buffer, "readinto") else self._memmove


### PR DESCRIPTION
Handling mmap as ctypes array (FPDF_LoadMemDocument64) might be better than as buffer (FPDF_LoadCustomDocument), to avoid unnecessary callbacks.

The way I understand mmap is that we can effectively treat it like regular memory without the file actually being fully in memory (i. e. the memory is a virtual view of a buffered stream, managed by the OS - access of the memory span maps to the stream).

But I'm not sure. The available information is rather scarce - maybe `.from_buffer()` just loads the mmap into memory as a whole?