### PR TITLE
add dependency: pillow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ name = "pypdfium2"
 description = "Python bindings to PDFium"
 readme = "README.md"
 requires-python = ">= 3.6"
+dependencies = [
+    "pillow",
+]
 dynamic = ["version"]
 keywords = ["pdf", "pdfium"]
 authors = [


### PR DESCRIPTION
without pillow, the runtime fails with

```
$ pypdfium2
ModuleNotFoundError: No module named 'PIL'
```