### PR TITLE
Add support for hermetic (internet-less) builds against binary pdfium releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,6 @@ As of early 2023, a single developer is author and rightsholder of the code base
 While using pypdfium2, you might encounter bugs or missing features.
 In this case, feel free to file an issue. If applicable, include details such as tracebacks, OS and CPU type, as well as the versions of pypdfium2 and used dependencies.
 
-Roadmap:
 * pypdfium2
   - [Issues panel](https://github.com/pypdfium2-team/pypdfium2/issues): Initial bug reports and feature requests. May need to be transferred to dependencies.
   - [Discussions page](https://github.com/pypdfium2-team/pypdfium2/discussions): General questions and suggestions.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ pypdfium2 includes helpers to simplify common use cases, while the raw PDFium/ct
     ```
     A binary is downloaded implicitly from `pdfium-binaries` and bundled into pypdfium2.
   
+  * With explicitly provided pre-downloaded binary (e.g. unpacked `pdfium-linux-x64.tgz`, useful for sandboxed offline packaging in Linux distributions):
+    ```bash
+    # Substitute `$PDFIUM_VER` with the system pdfium's numeric build version, e.g. `1234`.
+    # Substitute `linux_x64` with the corresponding platform name.
+    PDFIUM_PLATFORM="linux_x64:$PDFIUM_VER" \
+      PDFIUM_BINARIES_DIR=/path/to/pdfium/version/$PDFIUM_VER/ \
+      PDFIUM_HEADERS_DIR=/path/to/pdfium/version/$PDFIUM_VER/include/ \
+      python3 -m pip install -v .
+    ```
+
   * With self-built binary
     ```bash
     python3 setupsrc/pypdfium2_setup/build_pdfium.py  # call with --help to list options

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ The release process is fully automated using Python scripts and scheduled releas
 You may also trigger the workflow manually using the GitHub Actions panel or the [`gh`](https://cli.github.com/) command-line tool.
 
 Python release scripts are located in the folder `setupsrc/pypdfium2_setup`, along with custom setup code:
-* `update_pdfium.py` downloads binaries and generates the bindings.
+* `update_pdfium.py` downloads and extracts binaries.
 * `craft_packages.py pypi` builds platform-specific wheel packages and a source distribution suitable for PyPI upload.
 * `autorelease.py` takes care of versioning, changelog, release note generation and VCS checkin.
 

--- a/setup.py
+++ b/setup.py
@@ -138,13 +138,19 @@ def main():
     
     pl_spec = os.environ.get(PlatSpec_EnvVar, "")
     modspec = os.environ.get(ModulesSpec_EnvVar, "")
+
+    pdfium_binaries_dir_str = os.environ.get("PDFIUM_BINARIES_DIR", None)
+    pdfium_binaries_dir = None if pdfium_binaries_dir_str is None else Path(pdfium_binaries_dir_str)
+
+    headers_dir_str = os.environ.get("PDFIUM_HEADERS_DIR", None)
+    headers_dir = None if headers_dir_str is None else Path(headers_dir_str)
     
     # TODO embed is_prepared in version file? - in principle, it could be arbitrary caller-given files
     with_prepare, pl_name, pdfium_ver, use_v8 = parse_pl_spec(pl_spec)
     modnames = parse_modspec(modspec, pl_name)
     
     if ModuleRaw in modnames and with_prepare:
-        prepare_setup(pl_name, pdfium_ver, use_v8)
+        prepare_setup(pl_name, pdfium_ver, use_v8, headers_dir, pdfium_binaries_dir)
     run_setup(modnames, pl_name, pdfium_ver)
 
 

--- a/setupsrc/pypdfium2_setup/craft_packages.py
+++ b/setupsrc/pypdfium2_setup/craft_packages.py
@@ -168,7 +168,7 @@ def main_conda_bundle(args):
 
 def main_conda_raw(args):
     os.environ["PDFIUM_SHORT"] = str(args.pdfium_ver)
-    os.environ["PDFIUM_FULL"] = PdfiumVer.to_full(args.pdfium_ver, type=str)
+    os.environ["PDFIUM_FULL"] = PdfiumVer.to_full_from_fetched_git_refs(args.pdfium_ver, type=str)
     emplace_func = partial(prepare_setup, ExtPlats.system, args.pdfium_ver, use_v8=None)
     with CondaExtPlatfiles(emplace_func):
         run_conda_build(CondaDir/"raw", CondaDir/"raw"/"out")

--- a/setupsrc/pypdfium2_setup/update_pdfium.py
+++ b/setupsrc/pypdfium2_setup/update_pdfium.py
@@ -98,7 +98,7 @@ def main(platforms, version=None, robust=False, max_workers=None, use_v8=False):
 
 def parse_args(argv):
     parser = argparse.ArgumentParser(
-        description = "Download pre-built PDFium packages and generate bindings.",
+        description = "Download and extract pre-built PDFium packages.",
     )
     parser.add_argument(
         # FIXME with metavar, choices are not visible in help by default - without it, the long choices list is repeated 4 times due to 2 flags and nargs="+"

--- a/setupsrc/pypdfium2_setup/update_pdfium.py
+++ b/setupsrc/pypdfium2_setup/update_pdfium.py
@@ -76,8 +76,6 @@ def extract(archives, version, flags):
             tar_libdir = "lib" if system != SysNames.windows else "bin"
             tar_extract_file(tar, f"{tar_libdir}/{libname}", pl_dir/libname)
             write_pdfium_info(pl_dir, version, origin="pdfium-binaries", flags=flags)
-        
-        arc_path.unlink()
 
 
 def main(platforms, version=None, robust=False, max_workers=None, use_v8=False):


### PR DESCRIPTION
Fixes #272.

The env vars

```
PDFIUM_BINARIES_DIR
PDFIUM_HEADERS_DIR
```

are added which `setup.py` picks up.

See the commit messages for more details.