### PR TITLE
Experiment with getting full version from pdfium-binaries record

### DIFF
--- a/setupsrc/pypdfium2_setup/build_pdfium.py
+++ b/setupsrc/pypdfium2_setup/build_pdfium.py
@@ -177,7 +177,7 @@ def pack(v_short, v_post):
     
     libname = LibnameForSystem[Host.system]
     shutil.copy(PDFiumBuildDir/libname, dest_dir/libname)
-    v_full = PdfiumVer.full_from_refs(v_short)
+    v_full = PdfiumVer.to_full(v_short)
     write_pdfium_info(dest_dir, v_full, origin="sourcebuild", **v_post)
     
     # We want to use local headers instead of downloading with build_pdfium_bindings(), therefore call run_ctypesgen() directly

--- a/setupsrc/pypdfium2_setup/craft_packages.py
+++ b/setupsrc/pypdfium2_setup/craft_packages.py
@@ -168,7 +168,7 @@ def main_conda_bundle(args):
 
 def main_conda_raw(args):
     os.environ["PDFIUM_SHORT"] = str(args.pdfium_ver)
-    v_full = PdfiumVer.full_from_refs(args.pdfium_ver)
+    v_full = PdfiumVer.to_full(args.pdfium_ver)
     os.environ["PDFIUM_FULL"] = ".".join([str(v) for v in v_full])
     emplace_func = partial(prepare_setup, ExtPlats.system, args.pdfium_ver, use_v8=None)
     with CondaExtPlatfiles(emplace_func):

--- a/setupsrc/pypdfium2_setup/craft_packages.py
+++ b/setupsrc/pypdfium2_setup/craft_packages.py
@@ -168,7 +168,8 @@ def main_conda_bundle(args):
 
 def main_conda_raw(args):
     os.environ["PDFIUM_SHORT"] = str(args.pdfium_ver)
-    os.environ["PDFIUM_FULL"] = PdfiumVer.to_full(args.pdfium_ver, type=str)
+    v_full = PdfiumVer.full_from_refs(args.pdfium_ver)
+    os.environ["PDFIUM_FULL"] = ".".join([str(v) for v in v_full])
     emplace_func = partial(prepare_setup, ExtPlats.system, args.pdfium_ver, use_v8=None)
     with CondaExtPlatfiles(emplace_func):
         run_conda_build(CondaDir/"raw", CondaDir/"raw"/"out")

--- a/setupsrc/pypdfium2_setup/emplace.py
+++ b/setupsrc/pypdfium2_setup/emplace.py
@@ -53,7 +53,7 @@ def prepare_setup(pl_name, v_short, use_v8):
         # TODO add option for caller to pass in custom run_lds and headers_dir
         build_pdfium_bindings(v_short, flags=flags, guard_symbols=True, run_lds=[])
         shutil.copyfile(DataDir_Bindings/BindingsFN, ModuleDir_Raw/BindingsFN)
-        v_full = PdfiumVer.full_from_refs(v_short)
+        v_full = PdfiumVer.to_full(v_short)
         write_pdfium_info(ModuleDir_Raw, v_full, origin="system", flags=flags)
         return [BindingsFN, VersionFN]
     else:

--- a/setupsrc/pypdfium2_setup/emplace.py
+++ b/setupsrc/pypdfium2_setup/emplace.py
@@ -44,16 +44,17 @@ def _get_pdfium_with_cache(pl_name, req_ver, req_flags, use_v8):
     build_pdfium_bindings(req_ver, flags=req_flags, compile_lds=compile_lds)
 
 
-def prepare_setup(pl_name, pdfium_ver, use_v8):
+def prepare_setup(pl_name, v_short, use_v8):
     
     clean_platfiles()
     flags = ["V8", "XFA"] if use_v8 else []
     
     if pl_name == ExtPlats.system:
         # TODO add option for caller to pass in custom run_lds and headers_dir
-        build_pdfium_bindings(pdfium_ver, flags=flags, guard_symbols=True, run_lds=[])
+        build_pdfium_bindings(v_short, flags=flags, guard_symbols=True, run_lds=[])
         shutil.copyfile(DataDir_Bindings/BindingsFN, ModuleDir_Raw/BindingsFN)
-        write_pdfium_info(ModuleDir_Raw, pdfium_ver, origin="system", flags=flags)
+        v_full = PdfiumVer.full_from_refs(v_short)
+        write_pdfium_info(ModuleDir_Raw, v_full, origin="system", flags=flags)
         return [BindingsFN, VersionFN]
     else:
         platfiles = []
@@ -65,7 +66,7 @@ def prepare_setup(pl_name, pdfium_ver, use_v8):
             platfiles += [pl_dir/BindingsFN]
         else:
             platfiles += [DataDir_Bindings/BindingsFN]
-            _get_pdfium_with_cache(pl_name, pdfium_ver, flags, use_v8)
+            _get_pdfium_with_cache(pl_name, v_short, flags, use_v8)
         
         platfiles += [pl_dir/LibnameForSystem[system], pl_dir/VersionFN]
         for fp in platfiles:

--- a/setupsrc/pypdfium2_setup/packaging_base.py
+++ b/setupsrc/pypdfium2_setup/packaging_base.py
@@ -136,21 +136,23 @@ class PdfiumVer:
         if v_short not in cls._ver_cache:
             if record:
                 print(f"Getting full version for {v_short} from pdfium-binaries record", file=sys.stderr)
-                cls._from_record(v_short, record)
+                cls._from_record(record)
             else:
                 print(f"Getting full version for {v_short} from chromium refs", file=sys.stderr)
                 cls._from_refs(v_short)
         else:
             print(f"Getting full version for {v_short} from cache", file=sys.stderr)
         
-        return cls._ver_cache[v_short]
+        v_full = cls._ver_cache[v_short]
+        assert v_full.build == v_short
+        return v_full
     
     @classmethod
-    def _from_record(cls, v_short, record):
+    def _from_record(cls, record):
         record = record.strip().replace(" ", "")
         parsed = {k.lower(): int(v) for k, v in [l.split("=") for l in record.split("\n")]}
-        cls._ver_cache[v_short] = cls.scheme(**parsed)
-        assert cls._ver_cache[v_short].build == v_short
+        v_full = cls.scheme(**parsed)
+        cls._ver_cache[v_full.build] = v_full
     
     @classmethod
     def _from_refs(cls, v_short):

--- a/setupsrc/pypdfium2_setup/packaging_base.py
+++ b/setupsrc/pypdfium2_setup/packaging_base.py
@@ -135,8 +135,10 @@ class PdfiumVer:
         v_short = int(v_short)
         if v_short not in cls._ver_cache:
             if record:
+                print(f"Getting full version for {v_short} from pdfium-binaries record", file=sys.stderr)
                 cls._from_record(v_short, record)
             else:
+                print(f"Getting full version for {v_short} from chromium refs", file=sys.stderr)
                 cls._from_refs(v_short)
         else:
             print(f"Getting full version for {v_short} from cache", file=sys.stderr)
@@ -145,7 +147,6 @@ class PdfiumVer:
     
     @classmethod
     def _from_record(cls, v_short, record):
-        print(f"Getting full version for {v_short} from pdfium-binaries record", file=sys.stderr)
         record = record.strip().replace(" ", "")
         parsed = {k.lower(): int(v) for k, v in [l.split("=") for l in record.split("\n")]}
         cls._ver_cache[v_short] = cls.scheme(**parsed)
@@ -155,7 +156,6 @@ class PdfiumVer:
     def _from_refs(cls, v_short):
         # FIXME Can be fairly expensive - consider disk cache to avoid slowdown for consecutive process calls?
         
-        print(f"Getting full version for {v_short} from chromium refs", file=sys.stderr)
         rc = cls._refs_cache
         
         if rc["lines"] is None:

--- a/setupsrc/pypdfium2_setup/packaging_base.py
+++ b/setupsrc/pypdfium2_setup/packaging_base.py
@@ -138,12 +138,14 @@ class PdfiumVer:
                 cls._from_record(v_short, record)
             else:
                 cls._from_refs(v_short)
+        else:
+            print(f"Getting full version for {v_short} from cache", file=sys.stderr)
         
         return cls._ver_cache[v_short]
     
     @classmethod
     def _from_record(cls, v_short, record):
-        # Get full version from pdfium-binaries style VERSION file data.
+        print(f"Getting full version for {v_short} from pdfium-binaries record", file=sys.stderr)
         record = record.strip().replace(" ", "")
         parsed = {k.lower(): int(v) for k, v in [l.split("=") for l in record.split("\n")]}
         cls._ver_cache[v_short] = cls.scheme(**parsed)
@@ -151,10 +153,9 @@ class PdfiumVer:
     
     @classmethod
     def _from_refs(cls, v_short):
+        # FIXME Can be fairly expensive - consider disk cache to avoid slowdown for consecutive process calls?
         
-        # Get full version from chromium refs via ls-remote.
-        # FIXME Can be fairly expensive. Consider disk cache to avoid slowdown for consecutive process calls.
-        
+        print(f"Getting full version for {v_short} from chromium refs", file=sys.stderr)
         rc = cls._refs_cache
         
         if rc["lines"] is None:

--- a/setupsrc/pypdfium2_setup/packaging_base.py
+++ b/setupsrc/pypdfium2_setup/packaging_base.py
@@ -16,7 +16,7 @@ import sysconfig
 import traceback
 import subprocess
 from pathlib import Path
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 import urllib.request as url_request
 
 # TODO(apibreak) consider renaming PDFIUM_PLATFORM to PDFIUM_BINARY ?

--- a/setupsrc/pypdfium2_setup/update_pdfium.py
+++ b/setupsrc/pypdfium2_setup/update_pdfium.py
@@ -80,7 +80,7 @@ def extract(archives, v_short, flags):
             # all archives will have the same version, so the full version only has to be retrieved once.
             if v_full is None:
                 v_record = tar.extractfile("VERSION").read().decode("utf-8")
-                v_full = PdfiumVer.full_from_record(v_short, v_record)
+                v_full = PdfiumVer.to_full(v_short, v_record)
             write_pdfium_info(pl_dir, v_full, origin="pdfium-binaries", flags=flags)
         
         arc_path.unlink()

--- a/setupsrc/pypdfium2_setup/update_pdfium.py
+++ b/setupsrc/pypdfium2_setup/update_pdfium.py
@@ -65,7 +65,7 @@ def download(platforms, version, use_v8, max_workers, robust):
     return archives
 
 
-def extract(archives, version, flags):
+def extract(archives, v_short, flags):
     
     for pl_name, arc_path in archives.items():
         
@@ -75,7 +75,10 @@ def extract(archives, version, flags):
             libname = LibnameForSystem[system]
             tar_libdir = "lib" if system != SysNames.windows else "bin"
             tar_extract_file(tar, f"{tar_libdir}/{libname}", pl_dir/libname)
-            write_pdfium_info(pl_dir, version, origin="pdfium-binaries", flags=flags)
+            # FIXME all archives in this loop will have the same version info, so this would only have to be done once...
+            v_record = tar.extractfile("VERSION").read().decode()
+            v_full = PdfiumVer.full_from_record(v_short, v_record)
+            write_pdfium_info(pl_dir, v_full, origin="pdfium-binaries", flags=flags)
         
         arc_path.unlink()
 

--- a/setupsrc/pypdfium2_setup/update_pdfium.py
+++ b/setupsrc/pypdfium2_setup/update_pdfium.py
@@ -67,6 +67,8 @@ def download(platforms, version, use_v8, max_workers, robust):
 
 def extract(archives, v_short, flags):
     
+    v_full = None
+    
     for pl_name, arc_path in archives.items():
         
         with tarfile.open(arc_path) as tar:
@@ -75,9 +77,10 @@ def extract(archives, v_short, flags):
             libname = LibnameForSystem[system]
             tar_libdir = "lib" if system != SysNames.windows else "bin"
             tar_extract_file(tar, f"{tar_libdir}/{libname}", pl_dir/libname)
-            # FIXME all archives in this loop will have the same version info, so this would only have to be done once...
-            v_record = tar.extractfile("VERSION").read().decode()
-            v_full = PdfiumVer.full_from_record(v_short, v_record)
+            # all archives will have the same version, so the full version only has to be retrieved once.
+            if v_full is None:
+                v_record = tar.extractfile("VERSION").read().decode("utf-8")
+                v_full = PdfiumVer.full_from_record(v_short, v_record)
             write_pdfium_info(pl_dir, v_full, origin="pdfium-binaries", flags=flags)
         
         arc_path.unlink()


### PR DESCRIPTION
The design benefit of using the VERSION file is low (if any) IMO.

For refbindings and system, we still need the refs, so using the VERSION doesn't do much except add complexity.
It also looks cleaner to handle beforehand rather than in the loop, so I think we might be better off disk caching the remote refs to speed up consecutive process calls after all.

However, I like the style improvement of using a namedtuple (which is independent of the other change, though).