### PR TITLE
Presumably work around pdfium bug 2112

### DIFF
--- a/src/pypdfium2/_helpers/page.py
+++ b/src/pypdfium2/_helpers/page.py
@@ -325,7 +325,9 @@ class PdfPage (pdfium_i.AutoCloseable):
             rotation = 0,
             crop = (0, 0, 0, 0),
             may_draw_forms = True,
-            bitmap_maker = PdfBitmap.new_native,
+            # use foreign bitmap to work around https://crbug.com/pdfium/2112
+            # it should be changed back to native once the bug is fixed
+            bitmap_maker = PdfBitmap.new_foreign,
             color_scheme = None,
             fill_to_stroke = False,
             **kwargs


### PR DESCRIPTION
I am however reluctant to make a release with this as the bug would still wreak breakage on downstreams that use a non-default bitmap maker. Which would be unusual, but legit API use.

Also the issue seems to be very circumstance-specific and the cause in the control flow is not yet known to me (although we seem to have narrowed down the commit and relation to stride), so I am not certain if this would truly work around all cases.