### PR TITLE
Enable ppc64le wheel

### DIFF
--- a/setupsrc/pypdfium2_setup/packaging_base.py
+++ b/setupsrc/pypdfium2_setup/packaging_base.py
@@ -91,6 +91,7 @@ class PlatNames:
     linux_x86        = SysNames.linux   + "_x86"
     linux_arm64      = SysNames.linux   + "_arm64"
     linux_arm32      = SysNames.linux   + "_arm32"
+    linux_ppc64le    = SysNames.linux   + "_ppc64le"
     linux_musl_x64   = SysNames.linux   + "_musl_x64"
     linux_musl_x86   = SysNames.linux   + "_musl_x86"
     linux_musl_arm64 = SysNames.linux   + "_musl_arm64"
@@ -108,6 +109,7 @@ ReleaseNames = {
     PlatNames.linux_x86        : "linux-x86",
     PlatNames.linux_arm64      : "linux-arm64",
     PlatNames.linux_arm32      : "linux-arm",
+    PlatNames.linux_ppc64le    : "linux-ppc64le",
     PlatNames.linux_musl_x64   : "linux-musl-x64",
     PlatNames.linux_musl_x86   : "linux-musl-x86",
     PlatNames.linux_musl_arm64 : "linux-musl-arm64",
@@ -334,6 +336,8 @@ class _host_platform:
             return PlatNames.linux_arm64 if self._libc_name != "musl" else PlatNames.linux_musl_arm64
         elif self._is_plat("linux", "armv7l"):
             return PlatNames.linux_arm32
+        elif self._is_plat("linux", "ppc64le"):
+            return PlatNames.linux_ppc64le
         elif self._is_plat("windows", "amd64"):
             return PlatNames.windows_x64
         elif self._is_plat("windows", "arm64"):
@@ -365,6 +369,8 @@ def get_wheel_tag(pl_name):
         return _manylinux_tag("aarch64")
     elif pl_name == PlatNames.linux_arm32:
         return _manylinux_tag("armv7l")
+    elif pl_name == PlatNames.linux_ppc64le:
+        return _manylinux_tag("ppc64le")
     elif pl_name == PlatNames.linux_musl_x64:
         return "musllinux_1_1_x86_64"
     elif pl_name == PlatNames.linux_musl_x86:


### PR DESCRIPTION
**Important:** External contributors are required to comply with the template.

## Description

This PR enables ppc64le manylinux wheels. However it requires to build and provide the `libpdfium.so` manually for the moment as the upstream will probably take a bit more time.

A _quick and dirty_ way is to replace the download variable in `update_pdfium.py` like this and point it to the uploaded ppc64le lib before building the wheel:

```bash
sed -i "s/fu = .*/fu = \"https:\/\/github.com\/user-attachments\/files\/18456063\/pdfium-linux-ppc64le.tgz\"/g" setupsrc/pypdfium2_setup/update_pdfium.py
```

Once pdfium-binaries provide a `pdfium-linux-ppc64le.tgz`, GH actions can be updated accordingly to automatically build manylinux wheels.

## Checklist

<!--
- Answer the questions below, choosing the section(s) relevant to your PR. Non-applying sections shall be set to `closed`.
- Place an `x` in the [ ] for yes, leave it empty for no. If a question is not applicable, remove the [ ], but keep the message in place.
- Use the Preview tab to confirm the PR will render correctly.
-->

<details open><summary>Helpers</summary>

N/A

</details>
<details open><summary>Setup</summary>

- [x] This PR changes setup code (`setupsrc/`, `setup.py` etc.).
- [x] I have read through relevant doc sections [Installation -> From source][1] and [Setup Magic][2].
- [x] I have tested the change does not break internal callers.
- [x] I believe the change is maintainable and does not cause unreasonable complexity or code pollution.
- [x] The change does not try to shift a maintenance burden or upstream downstream tasks. *Keep handlers generic, avoid overly downstream-specific or (for us) effectively dead code passages.*
- [x] I have assessed that the targeted use case cannot reasonably be satisfied by existing means, such as [Caller-provided data files][3], or the change forms a notable improvement over possible alternatives.
- [ ] I believe the targeted use case is supported by pypdfium2-team. *Note that we may not want to support esoteric or artificially restricted setup envs.*

[1]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#install-source
[2]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#setup-magic
[3]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#install-source-caller

</details>
<details open><summary>Other</summary>

N/A

</details>
