### PR TITLE
Feature: `textpage` font helpers

### DIFF
--- a/src/pypdfium2/_helpers/textpage.py
+++ b/src/pypdfium2/_helpers/textpage.py
@@ -160,8 +160,57 @@ class PdfTextPage (pdfium_i.AutoCloseable):
         if n_rects == -1:
             raise PdfiumError("Failed to count rectangles.")
         return n_rects
-    
-    
+
+    def get_font_size(self, index=0):
+        """
+        Get the font size of a particular character.
+
+        Parameters:
+            index (int): Index of the character of interest.
+        Returns:
+            float: The font size of the particular character in points. Note
+                that PDFium outputs 1.0 when the font size is unknown.
+        """
+        font_size = pdfium_c.FPDFText_GetFontSize(self, index)
+        return font_size
+
+    def get_font_name(self, index=0):
+        """
+        Get the font name of a particular character.
+
+        Parameters:
+            index (int): Index of the character of interest.
+        Returns:
+            str | None : The font name of the particular character, or None
+                if the font name cannot be obtained.
+        """
+        flags = ctypes.c_int()
+        n_bytes = pdfium_c.FPDFText_GetFontInfo(self, index, None, 0, flags)
+        if n_bytes == 0:
+            # Gracefully handle errors since escape characters trigger these
+            return None
+        buffer = ctypes.create_string_buffer(n_bytes)
+        pdfium_c.FPDFText_GetFontInfo(self, index, buffer, n_bytes, flags)
+        # The NUL terminator is chopped off automatically
+        font_name = buffer.value.decode("utf-8")
+        return font_name
+
+    def get_font_weight(self, index=0):
+        """
+        Get the font weight of a particular character.
+
+        Parameters:
+            index (int): Index of the character of interest.
+        Returns:
+            int | None : The font weight of the particular character, or None
+                if the font weight cannot be obtained.
+        """
+        font_weight = pdfium_c.FPDFText_GetFontWeight(self, index)
+        if font_weight == -1:
+            # Gracefully handle errors since escape characters trigger these
+            return None
+        return font_weight
+
     def get_index(self, x, y, x_tol, y_tol):
         """
         Get the index of a character by position.

--- a/tests/test_textpage.py
+++ b/tests/test_textpage.py
@@ -151,3 +151,22 @@ def test_get_text_bounded_defaults_with_rotation():
     
     text = textpage.get_text_bounded()
     assert len(text) == 438
+
+@pytest.mark.parametrize(
+    "index,character,font_size,font_name,font_weight",
+    [
+        (0, "L", 16.0, "Ubuntu", 400),
+        (5, " ", 16.0, "Ubuntu", 400),
+        (27, "\r", 1.0, None, None),
+        (28, "\n", 1.0, None, None),
+        (43, "i", 16.0, "Ubuntu", 400),
+    ],
+)
+def test_get_font(index, character, font_size, font_name, font_weight):
+    pdf = pdfium.PdfDocument(TestFiles.text)
+    page = pdf[0]
+    textpage = page.get_textpage()
+    assert textpage.get_text_range(index, 1) == character
+    assert textpage.get_font_size(index) == font_size
+    assert textpage.get_font_name(index) == font_name
+    assert textpage.get_font_weight(index) == font_weight


### PR DESCRIPTION
## Description

This request adds helper functions to extract font-related information from `PdfTextPage`. A related feature request can be found in #358. Even though there are downstream packages that implement similar functionality, I think these features really belong here.

The implementation relies on two functions from PDFium's Experimental API, namely `FPDFText_GetFontInfo` and `FPDFText_GetFontWeight`, which, according to [this discussion](https://issues.chromium.org/issues/353746891), may be removed in the future in favour of another existing API. A few things to note here:

- If the experimental functions do get removed, the proposed implementation can be updated to use alternative functions in a backward compatible manner such that the end users of `pypdfium2` will not be affected.
- The functions proposed in the discussion are themselves marked as Experimental API, so using them does not offer a stability benefit either. In fact, `FPDFFont_GetFontName` mentioned there no longer exists and has been split into two other functions.
- Most importantly, these alternative functions from `FPDFFont_*` namespace require a font object that can be obtained from a text object, e.g.,

  ```python
  text_object = pdfium_c.FPDFText_GetTextObject(<PdfTextPage>, index)
  font = pdfium_c.FPDFTextObj_GetFont(text_object)
  ```
  
  Doing this in each helper function separately creates a significant overhead when one needs to get font size, family and weight together, resulting in ~25% slower execution. This overhead seems to be minimal if the font object is obtained just once and reused for further calls to get font information. However, this means that there would need to be a single function, e.g., `get_font_info` that returns an object containing font-related information. To me, the inclusion of such a function seems redundant but perhaps something you would want to consider in the future.

Let me know if you any thoughts on this.

## Checklist

<!--
- Use the Preview tab to see how the PR will render.
- Answer the questions below, choosing the section(s) relevant to your PR. Non-applying sections shall be set to `closed`.
- Place an `x` in the [ ] for yes, leave it empty for no. If a question is not applicable, remove the [ ], but keep the message in place.
-->

<details open><summary>Helpers</summary>

- [x] This PR changes helpers code.
- [x] The change comes with sufficient test cases to confirm correct functionality.
- [x] Any new test files are under a suitable license and have been registered in `REUSE.toml`. (Not applicable)

</details>
<details closed><summary>Setup</summary>

- [ ] This PR changes setup code (`setupsrc/`, `setup.py` etc.).
- [ ] I have at least skimmed through [Installation -> With setup][1] and subsections.
- [ ] I have tested the change does not break internal callers.
- [ ] I believe the change is maintainable and does not cause unreasonable complexity or code fragmentation.
- [ ] The change does not shift a maintenance burden or upstream downstream tasks. *Keep handlers generic, avoid overly downstream-specific or (for us) effectively dead code passages.*
- [ ] I have assessed that the targeted use case cannot reasonably be satisfied by existing means, such as [Caller-provided data files][2], or the change forms a notable improvement over possible alternatives.
- [ ] I believe the targeted use case is supported by pypdfium2-team. *Note that we may not want to support esoteric or artificially restricted setup envs.*

</details>
<details closed><summary>Other</summary>

- [ ] This PR changes other things, namely: ... <!-- sum up change (keyword/topic) -->

</details>

[1]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#from-the-repository--with-setup
[2]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#with-caller-provided-data-files
