### PR TITLE
Add PdfFont.is_embedded() and PdfTextPage.get_font_substitutions()

### DIFF
--- a/src/pypdfium2/__init__.py
+++ b/src/pypdfium2/__init__.py
@@ -5,3 +5,4 @@ import pypdfium2._library_scope
 from pypdfium2.version import *
 from pypdfium2._helpers import *
 from pypdfium2 import raw, internal
+from pypdfium2._font_tracking import get_font_requests, clear_font_requests

--- a/src/pypdfium2/_font_tracking.py
+++ b/src/pypdfium2/_font_tracking.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2025 geisserml <geisserml@gmail.com>
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+__all__ = ("get_font_requests", "clear_font_requests")
+
+import ctypes
+import threading
+import logging
+import pypdfium2.raw as pdfium_c
+import pypdfium2.internal as pdfium_i
+
+logger = logging.getLogger(__name__)
+
+# Module-level state — kept alive for the library lifetime.
+_default_info = None   # POINTER(FPDF_SYSFONTINFO) from FPDF_GetDefaultSystemFontInfo()
+_wrapper = None        # Our FPDF_SYSFONTINFO struct
+_cb_refs = []          # Strong refs to CFUNCTYPE objects to prevent GC
+_font_requests = {}    # {font_name_str: bool_found}
+_lock = threading.RLock()
+
+
+def _install_font_tracking():
+    """
+    Install a wrapper around PDFium's default system font info to intercept
+    MapFont/GetFont calls and log which fonts were found or missed.
+
+    Must be called after FPDF_InitLibraryWithConfig(). All fallible work
+    (getting default info, creating callbacks, building the wrapper) completes
+    before FPDF_SetSystemFontInfo() — the point of no return.
+    """
+    global _default_info, _wrapper, _cb_refs, _font_requests
+
+    # Step 1: Get a fresh default font info
+    default_info = pdfium_c.FPDF_GetDefaultSystemFontInfo()
+    if not default_info:
+        logger.debug("FPDF_GetDefaultSystemFontInfo() returned NULL; font tracking unavailable")
+        return
+
+    default = default_info.contents
+
+    # Step 2: Create all callback closures
+    # MapFont and GetFont intercept and log; all others are pure delegation.
+    # Intercepting callbacks use fail-open: delegate first, then try to log.
+    # An exception in logging must never affect the delegation result.
+
+    def _map_font(pThis, weight, italic, charset, pf, face, exact):
+        result = default.MapFont(default_info, weight, italic, charset, pf, face, exact)
+        try:
+            if face:
+                name = ctypes.string_at(face).decode("utf-8", errors="replace")
+                with _lock:
+                    if not _font_requests.get(name, False):
+                        _font_requests[name] = bool(result)
+        except Exception:
+            pass
+        return result
+
+    def _get_font(pThis, face):
+        result = default.GetFont(default_info, face)
+        try:
+            if face:
+                name = ctypes.string_at(face).decode("utf-8", errors="replace")
+                with _lock:
+                    if not _font_requests.get(name, False):
+                        _font_requests[name] = bool(result)
+        except Exception:
+            pass
+        return result
+
+    def _enum_fonts(pThis, mapper):
+        default.EnumFonts(default_info, mapper)
+
+    def _release(pThis):
+        if default.Release:
+            default.Release(default_info)
+
+    def _get_font_data(pThis, font, table, buffer, buf_size):
+        return default.GetFontData(default_info, font, table, buffer, buf_size)
+
+    def _get_face_name(pThis, font, buffer, buf_size):
+        return default.GetFaceName(default_info, font, buffer, buf_size)
+
+    def _get_font_charset(pThis, font):
+        return default.GetFontCharset(default_info, font)
+
+    def _delete_font(pThis, font):
+        default.DeleteFont(default_info, font)
+
+    # Step 3: Build wrapper struct and assign callbacks
+    wrapper = pdfium_c.FPDF_SYSFONTINFO()
+    wrapper.version = default.version
+
+    cb_refs = []
+    for fname, pyfunc in [
+        ("Release", _release),
+        ("EnumFonts", _enum_fonts),
+        ("MapFont", _map_font),
+        ("GetFont", _get_font),
+        ("GetFontData", _get_font_data),
+        ("GetFaceName", _get_face_name),
+        ("GetFontCharset", _get_font_charset),
+        ("DeleteFont", _delete_font),
+    ]:
+        pdfium_i.set_callback(wrapper, fname, pyfunc)
+        # Keep a strong ref to the ctypes callback object to prevent GC
+        cb_refs.append(getattr(wrapper, fname))
+
+    # Step 4: Assign module-level strong refs (before point of no return)
+    _default_info = default_info
+    _wrapper = wrapper
+    _cb_refs = cb_refs
+    _font_requests.clear()
+
+    # Step 5: Point of no return — install the wrapper
+    pdfium_c.FPDF_SetSystemFontInfo(_wrapper)
+
+
+def _reset_font_tracking():
+    """
+    Clear the font request log after FPDF_DestroyLibrary().
+
+    The wrapper, default_info, and callback refs are NOT cleared here —
+    they must remain alive during FPDF_DestroyLibrary() since PDFium calls
+    Release during shutdown. They become inert after destroy and are left
+    for process exit / GC.
+    """
+    with _lock:
+        _font_requests.clear()
+
+
+def get_font_requests():
+    """
+    Return the accumulated font resolution log.
+
+    Each entry maps a font name (as requested by PDFium via MapFont/GetFont)
+    to a boolean indicating whether the font was found on the system.
+
+    Font requests are accumulated across all page loads since library init
+    (or since the last call to :func:`clear_font_requests`).
+
+    Note:
+        The font names logged here are those passed to PDFium's MapFont/GetFont
+        callbacks, which may differ slightly from PDF BaseFont names (e.g.,
+        ``"NotoSansCJKsc"`` vs ``"NotoSansCJKsc-Regular"``). Some entries may
+        be internal PDFium probes rather than fonts referenced by a specific PDF.
+
+    Returns:
+        dict[str, bool]: Mapping of font name to found status.
+    """
+    with _lock:
+        return dict(_font_requests)
+
+
+def clear_font_requests():
+    """
+    Clear the accumulated font resolution log.
+    """
+    with _lock:
+        _font_requests.clear()

--- a/src/pypdfium2/_helpers/pageobjects.py
+++ b/src/pypdfium2/_helpers/pageobjects.py
@@ -252,16 +252,6 @@ class PdfFont (pdfium_i.AutoCastable):
             raise PdfiumError("Failed to get font weight.")
         return weight
 
-    def is_embedded(self):
-        """
-        Returns:
-            bool: True if the font is embedded in the PDF, False otherwise.
-        """
-        rc = pdfium_c.FPDFFont_GetIsEmbedded(self)
-        if rc == -1:
-            raise PdfiumError("Failed to determine font embedding status.")
-        return rc == 1
-
 
 class PdfImage (PdfObject):
     """

--- a/src/pypdfium2/_helpers/pageobjects.py
+++ b/src/pypdfium2/_helpers/pageobjects.py
@@ -252,6 +252,16 @@ class PdfFont (pdfium_i.AutoCastable):
             raise PdfiumError("Failed to get font weight.")
         return weight
 
+    def is_embedded(self):
+        """
+        Returns:
+            bool: True if the font is embedded in the PDF, False otherwise.
+        """
+        rc = pdfium_c.FPDFFont_GetIsEmbedded(self)
+        if rc == -1:
+            raise PdfiumError("Failed to determine font embedding status.")
+        return rc == 1
+
 
 class PdfImage (PdfObject):
     """

--- a/src/pypdfium2/_helpers/textpage.py
+++ b/src/pypdfium2/_helpers/textpage.py
@@ -245,6 +245,28 @@ class PdfTextPage (pdfium_i.AutoCloseable):
         return PdfTextObj(raw_obj, textpage=self)
     
     
+    def get_font_substitutions(self):
+        """
+        Get a mapping of non-embedded font substitutions on this page.
+
+        Iterates text objects on the page and, for each non-embedded font,
+        records what the PDF requested (base name) vs. what PDFium resolved (family name).
+
+        Returns:
+            dict[str, set[str]]:
+                Maps each non-embedded base font name to the set of family names
+                PDFium resolved it to. Empty dict if all fonts are embedded.
+        """
+        substitutions = {}
+        for obj in self.page.get_objects(filter=[pdfium_c.FPDF_PAGEOBJ_TEXT]):
+            font = obj.get_font()
+            if font.is_embedded():
+                continue
+            base_name = font.get_base_name()
+            family_name = font.get_family_name()
+            substitutions.setdefault(base_name, set()).add(family_name)
+        return substitutions
+
     def search(self, text, index=0, match_case=False, match_whole_word=False, consecutive=False, flags=0):
         """
         Locate text on the page.

--- a/src/pypdfium2/_helpers/textpage.py
+++ b/src/pypdfium2/_helpers/textpage.py
@@ -245,6 +245,33 @@ class PdfTextPage (pdfium_i.AutoCloseable):
         return PdfTextObj(raw_obj, textpage=self)
     
     
+    def get_font_substitutions(self):
+        """
+        Get a mapping of non-embedded font substitutions on this page.
+
+        Iterates text objects on the page and, for each non-embedded font,
+        records what the PDF requested (base name) vs. what PDFium resolved (family name).
+
+        See also:
+            :func:`pypdfium2.get_font_requests` for a callback-based approach that
+            logs exactly which fonts PDFium tried to resolve from the system.
+
+        Returns:
+            dict[str, set[str]]:
+                Maps each non-embedded base font name to the set of family names
+                PDFium resolved it to. Empty dict if all fonts are embedded.
+        """
+        substitutions = {}
+        for obj in self.page.get_objects(filter=[pdfium_c.FPDF_PAGEOBJ_TEXT]):
+            font = obj.get_font()
+            if font.is_embedded():
+                continue
+            base_name = font.get_base_name()
+            family_name = font.get_family_name()
+            substitutions.setdefault(base_name, set()).add(family_name)
+        return substitutions
+
+
     def search(self, text, index=0, match_case=False, match_whole_word=False, consecutive=False, flags=0):
         """
         Locate text on the page.

--- a/src/pypdfium2/_helpers/textpage.py
+++ b/src/pypdfium2/_helpers/textpage.py
@@ -245,28 +245,6 @@ class PdfTextPage (pdfium_i.AutoCloseable):
         return PdfTextObj(raw_obj, textpage=self)
     
     
-    def get_font_substitutions(self):
-        """
-        Get a mapping of non-embedded font substitutions on this page.
-
-        Iterates text objects on the page and, for each non-embedded font,
-        records what the PDF requested (base name) vs. what PDFium resolved (family name).
-
-        Returns:
-            dict[str, set[str]]:
-                Maps each non-embedded base font name to the set of family names
-                PDFium resolved it to. Empty dict if all fonts are embedded.
-        """
-        substitutions = {}
-        for obj in self.page.get_objects(filter=[pdfium_c.FPDF_PAGEOBJ_TEXT]):
-            font = obj.get_font()
-            if font.is_embedded():
-                continue
-            base_name = font.get_base_name()
-            family_name = font.get_family_name()
-            substitutions.setdefault(base_name, set()).add(family_name)
-        return substitutions
-
     def search(self, text, index=0, match_case=False, match_whole_word=False, consecutive=False, flags=0):
         """
         Locate text on the page.

--- a/src/pypdfium2/_library_scope.py
+++ b/src/pypdfium2/_library_scope.py
@@ -26,12 +26,25 @@ def init_lib():
     pdfium_c.FPDF_InitLibraryWithConfig(config)
     pdfium_i.LIBRARY_AVAILABLE.value = True
 
+    try:
+        from pypdfium2._font_tracking import _install_font_tracking
+        _install_font_tracking()
+    except Exception:
+        pass
+
 
 def destroy_lib():  # pragma: no cover
     assert pdfium_i.LIBRARY_AVAILABLE
     if pdfium_i.DEBUG_AUTOCLOSE:
         pdfium_i._safe_debug("Destroy PDFium")
     pdfium_c.FPDF_DestroyLibrary()
+
+    try:
+        from pypdfium2._font_tracking import _reset_font_tracking
+        _reset_font_tracking()
+    except Exception:
+        pass
+
     pdfium_i.LIBRARY_AVAILABLE.value = False
 
 

--- a/src/pypdfium2/_library_scope.py
+++ b/src/pypdfium2/_library_scope.py
@@ -3,8 +3,11 @@
 
 import sys
 import atexit
+import logging
 import pypdfium2.raw as pdfium_c
 import pypdfium2.internal as pdfium_i
+
+logger = logging.getLogger(__name__)
 
 
 def init_lib():
@@ -30,7 +33,7 @@ def init_lib():
         from pypdfium2._font_tracking import _install_font_tracking
         _install_font_tracking()
     except Exception:
-        pass
+        logger.debug("Failed to install font tracking", exc_info=True)
 
 
 def destroy_lib():  # pragma: no cover
@@ -43,7 +46,7 @@ def destroy_lib():  # pragma: no cover
         from pypdfium2._font_tracking import _reset_font_tracking
         _reset_font_tracking()
     except Exception:
-        pass
+        logger.debug("Failed to reset font tracking", exc_info=True)
 
     pdfium_i.LIBRARY_AVAILABLE.value = False
 

--- a/tests/test_font_tracking.py
+++ b/tests/test_font_tracking.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 geisserml <geisserml@gmail.com>
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+import sys
+import subprocess
+import pypdfium2 as pdfium
+from .conftest import TestFiles
+
+
+# Minimal PDF with a non-embedded reference to a non-existent font ("FakeTestFont").
+FAKE_FONT_PDF = (
+    b"%PDF-1.0\n"
+    b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+    b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+    b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+    b"/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n"
+    b"4 0 obj<</Length 23>>\nstream\nBT /F1 12 Tf (X) Tj ET\nendstream\nendobj\n"
+    b"5 0 obj<</Type/Font/Subtype/Type1/BaseFont/FakeTestFont>>endobj\n"
+    b"xref\n0 6\n"
+    b"0000000000 65535 f \n"
+    b"0000000009 00000 n \n"
+    b"0000000052 00000 n \n"
+    b"0000000101 00000 n \n"
+    b"0000000211 00000 n \n"
+    b"0000000280 00000 n \n"
+    b"trailer<</Size 6/Root 1 0 R>>\nstartxref\n344\n%%EOF\n"
+)
+
+
+def test_font_requests_fake_font():
+    pdfium.clear_font_requests()
+    pdf = pdfium.PdfDocument(FAKE_FONT_PDF)
+    page = pdf[0]
+    page.get_textpage()
+
+    requests = pdfium.get_font_requests()
+    fake_entries = {k: v for k, v in requests.items() if "FakeTestFont" in k}
+    assert len(fake_entries) > 0
+    assert any(v is False for v in fake_entries.values())
+
+
+def test_font_requests_embedded():
+    pdfium.clear_font_requests()
+    pdf = pdfium.PdfDocument(TestFiles.text)
+    page = pdf[0]
+    page.get_textpage()
+
+    requests = pdfium.get_font_requests()
+    # text.pdf uses embedded Ubuntu font — embedded fonts don't trigger MapFont/GetFont
+    assert requests == {}
+
+
+def test_clear_font_requests():
+    # Populate the log
+    pdf = pdfium.PdfDocument(FAKE_FONT_PDF)
+    page = pdf[0]
+    page.get_textpage()
+    assert pdfium.get_font_requests() != {}
+
+    pdfium.clear_font_requests()
+    assert pdfium.get_font_requests() == {}
+
+
+def test_font_tracking_clean_exit():
+    import os
+    env = os.environ.copy()
+    # Ensure the child can import the local package in source-tree/dev setups
+    src_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+    env["PYTHONPATH"] = src_dir + os.pathsep + env.get("PYTHONPATH", "")
+
+    result = subprocess.run(
+        [sys.executable, "-c", (
+            "import pypdfium2 as pdfium; "
+            "pdf = pdfium.PdfDocument(%r); "
+            "page = pdf[0]; "
+            "tp = page.get_textpage(); "
+        ) % FAKE_FONT_PDF],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+    # Check for signs of callback/teardown problems
+    for marker in ["Traceback", "Exception ignored", "Error in atexit"]:
+        assert marker not in result.stderr, f"Found {marker!r} in stderr: {result.stderr!r}"

--- a/tests/test_textpage.py
+++ b/tests/test_textpage.py
@@ -5,7 +5,29 @@ import re
 import pytest
 import pypdfium2 as pdfium
 import pypdfium2.raw as pdfium_c
+from unittest.mock import patch
+from pypdfium2._helpers.misc import PdfiumError
 from .conftest import TestFiles
+
+
+# Minimal PDF with a non-embedded reference to a non-existent font ("FakeTestFont").
+FAKE_FONT_PDF = (
+    b"%PDF-1.0\n"
+    b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+    b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+    b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+    b"/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n"
+    b"4 0 obj<</Length 23>>\nstream\nBT /F1 12 Tf (X) Tj ET\nendstream\nendobj\n"
+    b"5 0 obj<</Type/Font/Subtype/Type1/BaseFont/FakeTestFont>>endobj\n"
+    b"xref\n0 6\n"
+    b"0000000000 65535 f \n"
+    b"0000000009 00000 n \n"
+    b"0000000052 00000 n \n"
+    b"0000000101 00000 n \n"
+    b"0000000211 00000 n \n"
+    b"0000000280 00000 n \n"
+    b"trailer<</Size 6/Root 1 0 R>>\nstartxref\n344\n%%EOF\n"
+)
 
 
 @pytest.fixture
@@ -185,3 +207,45 @@ def test_font_helpers(
         assert fontobj.get_base_name() == base_name
         assert fontobj.get_family_name() == family_name
         assert fontobj.get_weight() == weight
+
+
+def test_font_is_embedded():
+    pdf = pdfium.PdfDocument(TestFiles.text)
+    page = pdf[0]
+    textpage = page.get_textpage()
+    textobj = textpage.get_textobj(0)
+    font = textobj.get_font()
+    assert font.is_embedded() is True
+
+
+def test_font_is_embedded_failure():
+    pdf = pdfium.PdfDocument(TestFiles.text)
+    page = pdf[0]
+    textpage = page.get_textpage()
+    font = textpage.get_textobj(0).get_font()
+    with patch.object(pdfium_c, "FPDFFont_GetIsEmbedded", return_value=-1):
+        with pytest.raises(PdfiumError, match="Failed to determine font embedding status"):
+            font.is_embedded()
+
+
+def test_get_font_substitutions_embedded(textpage):
+    subs = textpage.get_font_substitutions()
+    assert subs == {}
+
+
+def test_get_font_substitutions_empty_page():
+    pdf = pdfium.PdfDocument(TestFiles.empty)
+    page = pdf[0]
+    textpage = page.get_textpage()
+    subs = textpage.get_font_substitutions()
+    assert subs == {}
+
+
+def test_get_font_substitutions_fake_font():
+    pdf = pdfium.PdfDocument(FAKE_FONT_PDF)
+    page = pdf[0]
+    textpage = page.get_textpage()
+    subs = textpage.get_font_substitutions()
+    assert "FakeTestFont" in subs
+    assert isinstance(subs["FakeTestFont"], set)
+    assert len(subs["FakeTestFont"]) > 0

--- a/tests/test_textpage.py
+++ b/tests/test_textpage.py
@@ -5,30 +5,7 @@ import re
 import pytest
 import pypdfium2 as pdfium
 import pypdfium2.raw as pdfium_c
-from pypdfium2._helpers.pageobjects import PdfFont
-from pypdfium2._helpers.misc import PdfiumError
 from .conftest import TestFiles
-
-
-# Minimal PDF with a non-embedded reference to a non-existent font ("FakeTestFont").
-# The text "X" is drawn using this font, so PDFium will substitute it.
-FAKE_FONT_PDF = (
-    b"%PDF-1.0\n"
-    b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
-    b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
-    b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
-    b"/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n"
-    b"4 0 obj<</Length 23>>\nstream\nBT /F1 12 Tf (X) Tj ET\nendstream\nendobj\n"
-    b"5 0 obj<</Type/Font/Subtype/Type1/BaseFont/FakeTestFont>>endobj\n"
-    b"xref\n0 6\n"
-    b"0000000000 65535 f \n"
-    b"0000000009 00000 n \n"
-    b"0000000052 00000 n \n"
-    b"0000000101 00000 n \n"
-    b"0000000211 00000 n \n"
-    b"0000000280 00000 n \n"
-    b"trailer<</Size 6/Root 1 0 R>>\nstartxref\n344\n%%EOF\n"
-)
 
 
 @pytest.fixture
@@ -208,41 +185,3 @@ def test_font_helpers(
         assert fontobj.get_base_name() == base_name
         assert fontobj.get_family_name() == family_name
         assert fontobj.get_weight() == weight
-
-
-def test_font_is_embedded(textpage):
-    # text.pdf has embedded Ubuntu font
-    textobj = textpage.get_textobj(0)
-    font = textobj.get_font()
-    assert font.is_embedded() is True
-
-
-def test_font_is_embedded_failure():
-    # A null FPDF_FONT handle triggers FPDFFont_GetIsEmbedded returning -1
-    font = PdfFont(pdfium_c.FPDF_FONT())
-    with pytest.raises(PdfiumError, match="Failed to determine font embedding status."):
-        font.is_embedded()
-
-
-def test_get_font_substitutions_embedded(textpage):
-    # text.pdf has all fonts embedded, so no substitutions
-    subs = textpage.get_font_substitutions()
-    assert subs == {}
-
-
-def test_get_font_substitutions_empty_page():
-    pdf = pdfium.PdfDocument(TestFiles.empty)
-    page = pdf[0]
-    textpage = page.get_textpage()
-    subs = textpage.get_font_substitutions()
-    assert subs == {}
-
-
-def test_get_font_substitutions_fake_font():
-    pdf = pdfium.PdfDocument(FAKE_FONT_PDF)
-    page = pdf[0]
-    textpage = page.get_textpage()
-    subs = textpage.get_font_substitutions()
-    assert "FakeTestFont" in subs
-    assert isinstance(subs["FakeTestFont"], set)
-    assert len(subs["FakeTestFont"]) > 0

--- a/tests/test_textpage.py
+++ b/tests/test_textpage.py
@@ -5,7 +5,30 @@ import re
 import pytest
 import pypdfium2 as pdfium
 import pypdfium2.raw as pdfium_c
+from pypdfium2._helpers.pageobjects import PdfFont
+from pypdfium2._helpers.misc import PdfiumError
 from .conftest import TestFiles
+
+
+# Minimal PDF with a non-embedded reference to a non-existent font ("FakeTestFont").
+# The text "X" is drawn using this font, so PDFium will substitute it.
+FAKE_FONT_PDF = (
+    b"%PDF-1.0\n"
+    b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+    b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+    b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+    b"/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n"
+    b"4 0 obj<</Length 23>>\nstream\nBT /F1 12 Tf (X) Tj ET\nendstream\nendobj\n"
+    b"5 0 obj<</Type/Font/Subtype/Type1/BaseFont/FakeTestFont>>endobj\n"
+    b"xref\n0 6\n"
+    b"0000000000 65535 f \n"
+    b"0000000009 00000 n \n"
+    b"0000000052 00000 n \n"
+    b"0000000101 00000 n \n"
+    b"0000000211 00000 n \n"
+    b"0000000280 00000 n \n"
+    b"trailer<</Size 6/Root 1 0 R>>\nstartxref\n344\n%%EOF\n"
+)
 
 
 @pytest.fixture
@@ -185,3 +208,41 @@ def test_font_helpers(
         assert fontobj.get_base_name() == base_name
         assert fontobj.get_family_name() == family_name
         assert fontobj.get_weight() == weight
+
+
+def test_font_is_embedded(textpage):
+    # text.pdf has embedded Ubuntu font
+    textobj = textpage.get_textobj(0)
+    font = textobj.get_font()
+    assert font.is_embedded() is True
+
+
+def test_font_is_embedded_failure():
+    # A null FPDF_FONT handle triggers FPDFFont_GetIsEmbedded returning -1
+    font = PdfFont(pdfium_c.FPDF_FONT())
+    with pytest.raises(PdfiumError, match="Failed to determine font embedding status."):
+        font.is_embedded()
+
+
+def test_get_font_substitutions_embedded(textpage):
+    # text.pdf has all fonts embedded, so no substitutions
+    subs = textpage.get_font_substitutions()
+    assert subs == {}
+
+
+def test_get_font_substitutions_empty_page():
+    pdf = pdfium.PdfDocument(TestFiles.empty)
+    page = pdf[0]
+    textpage = page.get_textpage()
+    subs = textpage.get_font_substitutions()
+    assert subs == {}
+
+
+def test_get_font_substitutions_fake_font():
+    pdf = pdfium.PdfDocument(FAKE_FONT_PDF)
+    page = pdf[0]
+    textpage = page.get_textpage()
+    subs = textpage.get_font_substitutions()
+    assert "FakeTestFont" in subs
+    assert isinstance(subs["FakeTestFont"], set)
+    assert len(subs["FakeTestFont"]) > 0


### PR DESCRIPTION
## Description

Add two new APIs for detecting non-embedded font substitutions, using PDFium-native APIs only (no platform-specific code):

### `PdfFont.is_embedded()`
Wraps `FPDFFont_GetIsEmbedded()`. Returns `True` if the font is embedded in the PDF, `False` otherwise. Raises `PdfiumError` on the `-1` failure case (rather than masking it as `True` via `bool()`).

### `PdfTextPage.get_font_substitutions()`
Iterates text objects on the page via `page.get_objects(filter=[FPDF_PAGEOBJ_TEXT])`. For each non-embedded font, compares:
- `FPDFFont_GetBaseFontName()` — what the PDF requested
- `FPDFFont_GetFamilyName()` — what PDFium actually resolved to

Returns `dict[str, set[str]]` — maps each non-embedded base font name to the set of family names PDFium resolved it to. Uses `set` because the same base name could theoretically resolve to different families across objects with different FontDescriptor flags. Returns empty dict if all fonts are embedded.

No `textpage` assignment is needed — `get_font()`, `is_embedded()`, `get_base_name()`, and `get_family_name()` all work without a textpage. The method is opt-in (not called during `render()`).

### Example

```python
pdf = pdfium.PdfDocument("document.pdf")
page = pdf[0]
tp = page.get_textpage()
subs = tp.get_font_substitutions()
# On Linux without CJK fonts:
# {'NotoSansCJKsc-Regular': {'Chrome Sans MM'}}
# On Linux with fonts-noto-cjk installed:
# {'NotoSansCJKsc-Regular': {'Noto Sans CJK SC'}}
# On a PDF with all fonts embedded:
# {}
```

The user inspects the mapping and judges — `Chrome Sans MM` means PDFium fell back to its generic substitute (font missing), while a real family name like `Arial` or `Noto Sans CJK SC` means the system resolved it correctly.

### Empirically verified substitution behavior

| Scenario | Base Name | Family Name |
|---|---|---|
| Embedded | Ubuntu | Ubuntu |
| Resolved from system | Helvetica | Arial |
| Resolved from system | STSong | Songti SC |
| PDFium built-in | Symbol | Chrom Symbol OTF |
| **Missing font** | **NotoSansCJKsc-Regular** | **Chrome Sans MM** |
| **Missing font** | **SimSun** | **Chrome Sans MM** |

### Tests
- `test_font_is_embedded` — embedded Ubuntu font returns `True`
- `test_font_is_embedded_failure` — null `FPDF_FONT` handle raises `PdfiumError`
- `test_get_font_substitutions_embedded` — text.pdf (all fonts embedded) → `{}`
- `test_get_font_substitutions_empty_page` — empty.pdf → `{}`
- `test_get_font_substitutions_fake_font` — handcrafted inline PDF with non-existent `FakeTestFont` → detected in substitutions

Verified on macOS and Linux (Docker). Also tested with the original bug file where `NotoSansCJKsc-Regular` → `Chrome Sans MM` on a bare Linux container.

## Checklist

<details open><summary>Helpers</summary>

- [x] This PR changes helpers code.
- [x] The change comes with sufficient test cases to confirm correct functionality.
- [ ] Any new test files are under a suitable license and have been registered in `REUSE.toml`.

</details>
<details closed><summary>Setup</summary>

- [ ] This PR changes setup code (`setupsrc/`, `setup.py` etc.).
- [ ] I have at least skimmed through [Installation -> With setup][1] and subsections.
- [ ] I have tested the change does not break internal callers.
- [ ] I believe the change is maintainable and does not cause unreasonable complexity or code fragmentation.
- [ ] The change does not shift a maintenance burden or upstream downstream tasks. *Keep handlers generic, avoid overly downstream-specific or (for us) effectively dead code passages.*
- [ ] I have assessed that the targeted use case cannot reasonably be satisfied by existing means, such as [Caller-provided data files][2], or the change forms a notable improvement over possible alternatives.
- [ ] I believe the targeted use case is supported by pypdfium2-team. *Note that we may not want to support esoteric or artificially restricted setup envs.*

</details>
<details closed><summary>Other</summary>

- [ ] This PR changes other things, namely: ...

</details>

[1]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#from-the-repository--with-setup
[2]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#with-caller-provided-data-files