### PR TITLE
Deduplicate workflow inputs, migrate from `benc-uk/workflow-dispatch` to reusable workflow call

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,3 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
-    ignore:
-      - dependency-name: "benc-uk/workflow-dispatch"
-        versions: ["121"]  # presumably an upstream accident

--- a/.github/workflows/cibw.yaml
+++ b/.github/workflows/cibw.yaml
@@ -6,33 +6,33 @@ on:
   workflow_dispatch:
     inputs:
       cibw_py_ver:
-        default: 'cp314'
         type: string
+        default: 'cp314'
       linux_main:
-        default: true
         type: boolean
+        default: true
       linux_fastemu:
-        default: true
         type: boolean
+        default: true
       linux_clangcross:
-        default: true
         type: boolean
+        default: true
       linux_glibc:
-        default: true
         type: boolean
+        default: true
       linux_musl:
-        default: true
         type: boolean
+        default: true
       test_pdfium:
-        default: true
         type: boolean
+        default: true
       # we're using the toolchained build for macOS and Windows for now
       macos:
-        default: true
         type: boolean
+        default: true
       windows:
-        default: true
         type: boolean
+        default: true
 
 jobs:
   

--- a/.github/workflows/cibw_one.yaml
+++ b/.github/workflows/cibw_one.yaml
@@ -38,7 +38,7 @@ jobs:
   build:
     name: ${{ inputs.cibw_target }} on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
-    if: ${{ inputs.condition || inputs.condition == '' }}
+    if: ${{ inputs.condition }}
     
     steps:
       

--- a/.github/workflows/cibw_one.yaml
+++ b/.github/workflows/cibw_one.yaml
@@ -16,8 +16,9 @@ on:
         type: string
         required: true
       cibw_py_ver:
-        default: 'cp314'
         type: string
+        default: 'cp314'
+        required: true
       branch:
         type: string
         default: ''

--- a/.github/workflows/cibw_one.yaml
+++ b/.github/workflows/cibw_one.yaml
@@ -5,13 +5,16 @@
 name: CIBW build one
 on:
   workflow_call:
-    inputs:
+    inputs: &reusable_inputs
       os:
         type: string
+        required: true
       cibw_target:
         type: string
+        required: true
       cibw_arch:
         type: string
+        required: true
       cibw_py_ver:
         default: 'cp314'
         type: string
@@ -28,28 +31,7 @@ on:
         type: boolean
         default: true
   workflow_dispatch:
-    inputs:
-      os:
-        type: string
-        default: ubuntu-latest
-      cibw_target:
-        type: string
-        default: manylinux_x86_64
-      cibw_arch:
-        type: string
-        default: x86_64
-      cibw_py_ver:
-        default: 'cp314'
-        type: string
-      branch:
-        type: string
-        default: ''
-      repo_tag:
-        type: string
-        default: ''
-      test_pdfium:
-        type: boolean
-        default: true
+    inputs: *reusable_inputs
 
 jobs:
   

--- a/.github/workflows/cibw_one.yaml
+++ b/.github/workflows/cibw_one.yaml
@@ -18,7 +18,6 @@ on:
       cibw_py_ver:
         type: string
         default: 'cp314'
-        # required: true
       branch:
         type: string
         default: ''

--- a/.github/workflows/cibw_one.yaml
+++ b/.github/workflows/cibw_one.yaml
@@ -18,7 +18,7 @@ on:
       cibw_py_ver:
         type: string
         default: 'cp314'
-        required: true
+        # required: true
       branch:
         type: string
         default: ''

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -10,7 +10,7 @@ on:
         required: true
       py_ver:
         type: string
-        default: '3.14'
+        default: '3.12'
       pdfium_ver:
         type: string
         default: ''  # implies latest

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -11,7 +11,7 @@ on:
       py_ver:
         type: string
         default: '3.14'
-        required: true
+        # required: true
       pdfium_ver:
         type: string
         default: ''  # implies latest

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -10,7 +10,7 @@ on:
         required: true
       py_ver:
         type: string
-        default: '3.12'
+        default: '3.13'
       pdfium_ver:
         type: string
         default: ''  # implies latest
@@ -98,6 +98,13 @@ jobs:
         # Can't test 'windows-11-arm' because setup-miniconda doesn't support it AOTW
         os: ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-15-intel', 'macos-latest', 'windows-latest']
         py: ['3.8', '3.14']  # '3.9', '3.10', '3.11', '3.12', '3.13',
+        # conda macos-15-intel doesn't seem to like python 3.14 yet - downgrade to 3.13
+        exclude:
+          - os: macos-15-intel
+            py: '3.14'
+        include:
+          - os: macos-15-intel
+            py: '3.13'
     
     runs-on: ${{ matrix.os }}
     

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -11,7 +11,6 @@ on:
       py_ver:
         type: string
         default: '3.14'
-        # required: true
       pdfium_ver:
         type: string
         default: ''  # implies latest

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -3,33 +3,34 @@
 
 name: Conda packaging
 on:
-  workflow_dispatch:
-    inputs:
+  workflow_call:
+    inputs: &reusable_inputs
       package:
-        type: choice
-        default: raw
-        options:
-          - raw
-          - helpers
-      pdfium_ver:
-        default: 'latest'
         type: string
-      new_only:
-        # only with package == "raw", ignored otherwise (actually the default should be false in that case, but don't know if GH supports dynamic defaults depending on other inputs)
-        default: true
-        type: boolean
-      test:
-        default: true
-        type: boolean
-      publish:
-        default: false
-        type: boolean
+        default: raw  # choices: "raw" or "helpers"
+        required: true
       py_ver:
+        type: string
         default: '3.14'
+        required: true
+      pdfium_ver:
         type: string
+        default: ''  # implies latest
+      new_only:
+        # only with package == "raw", ignored otherwise
+        type: boolean
+        default: true
+      test:
+        type: boolean
+        default: true
+      publish:
+        type: boolean
+        default: false
       ref:
-        default: ''
         type: string
+        default: ''
+  workflow_dispatch:
+    inputs: *reusable_inputs
 
 # This is required for setup-miniconda / conda init
 # see https://github.com/conda-incubator/setup-miniconda#important
@@ -76,10 +77,10 @@ jobs:
           python -m pip install -U -r req/setup.txt
       
       - name: Build package
-        run: python3 conda/craft_conda_pkgs.py "$PACKAGE" --pdfium-ver "$PDFIUM_VER" $MAYBE_NEW_ONLY
+        run: python3 conda/craft_conda_pkgs.py "$PACKAGE" $VERSION_PARAM $MAYBE_NEW_ONLY
         env:
           PACKAGE: ${{ inputs.package }}
-          PDFIUM_VER: ${{ inputs.pdfium_ver }}
+          VERSION_PARAM: ${{ inputs.pdfium_ver && format('--pdfium-ver {0}', inputs.pdfium_ver) }}
           MAYBE_NEW_ONLY: ${{ inputs.package == 'raw' && inputs.new_only && '--new-only' || '' }}
       
       - name: Upload artifact

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -6,8 +6,7 @@ on:
   workflow_call:
     inputs: &reusable_inputs
       package:
-        type: string
-        default: raw  # choices: "raw" or "helpers"
+        type: string  # choices: "raw" or "helpers"
         required: true
       py_ver:
         type: string

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -10,7 +10,8 @@ on:
         required: true
       py_ver:
         type: string
-        default: '3.13'
+        # AOTW, conda still has some problems with 3.13 and 3.14
+        default: '3.12'
       pdfium_ver:
         type: string
         default: ''  # implies latest
@@ -98,13 +99,12 @@ jobs:
         # Can't test 'windows-11-arm' because setup-miniconda doesn't support it AOTW
         os: ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-15-intel', 'macos-latest', 'windows-latest']
         py: ['3.8', '3.14']  # '3.9', '3.10', '3.11', '3.12', '3.13',
-        # conda macos-15-intel doesn't seem to like python 3.14 yet - downgrade to 3.13
         exclude:
           - os: macos-15-intel
             py: '3.14'
         include:
           - os: macos-15-intel
-            py: '3.13'
+            py: '3.12'
     
     runs-on: ${{ matrix.os }}
     

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -4,8 +4,13 @@
 name: Update Docs (GH Pages)
 
 on:
-  workflow_dispatch:
   workflow_call:
+    inputs: &reusable_inputs
+      publish:
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs: &reusable_inputs
   # push:
   #   branches:
   #     - main
@@ -60,6 +65,7 @@ jobs:
   
   publish:
     needs: build
+    if: ${{ inputs.publish }}
     runs-on: ubuntu-latest
     
     # Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
         default: false
   workflow_dispatch:
-    inputs: &reusable_inputs
+    inputs: *reusable_inputs
   # push:
   #   branches:
   #     - main

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,8 +37,7 @@ defaults:
 
 jobs:
   
-  # TODO Split packaging across native hosts, merging build and test jobs (autorelease stuff can be handled in a prepare job before).
-  # Even merging with augment_cibw and augment_sbuild might be possible. This would allow us to easily switch between different build strategies.
+  # TODO Split packaging across native hosts, merging build and test jobs (autorelease.py can be run in a prepare job before). Add ability to select build strategy (binaries, sbuild, cibw) per target.
   
   build:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -381,6 +381,7 @@ jobs:
         with:
           packages-dir: dist/  # the default
       
+      # here we already have the repo, so using local workflow will work
       - name: Trigger GH Pages rebuild
         uses: ./.github/workflows/gh_pages.yaml  # takes no inputs
   
@@ -391,6 +392,10 @@ jobs:
     runs-on: ${{ inputs.runner }}
     
     steps:
+      
+      - name: Check out repo to run local workflow
+        uses: actions/checkout@v6
+      
       - name: Trigger conda pypdfium2_helpers build
         uses: ./.github/workflows/conda.yaml
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -383,7 +383,8 @@ jobs:
   
   gh_pages:
     needs: publish
-    if: ${{ inputs.publish && !cancelled() && !contains(needs.*.result, 'failure') }}
+    # XXX testing
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') }}  # inputs.publish &&
     uses: ./.github/workflows/gh_pages.yaml  # takes no inputs
   
   conda:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,9 @@ on:
       publish:
         type: boolean
         default: false
+      gh_pages:
+        type: boolean
+        default: false
       conda:
         type: boolean
         default: false
@@ -382,13 +385,14 @@ jobs:
           packages-dir: dist/  # the default
   
   gh_pages:
-    needs: publish
-    # XXX testing
-    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') }}  # inputs.publish &&
-    uses: ./.github/workflows/gh_pages.yaml  # takes no inputs
+    needs: publish  # i.e. goes after, regardless if publish is active or not
+    if: ${{ inputs.gh_pages && !cancelled() && !contains(needs.*.result, 'failure') }}
+    uses: ./.github/workflows/gh_pages.yaml
+    with:
+      publish: ${{ inputs.publish }}
   
   conda:
-    needs: publish  # i.e. goes after, regardless if publish is active or not
+    needs: publish
     if: ${{ inputs.conda && !cancelled() && !contains(needs.*.result, 'failure') }}
     uses: ./.github/workflows/conda.yaml
     with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,8 +5,8 @@
 
 name: Main packaging
 on:
-  workflow_call: &reusable_inputs
-    inputs:
+  workflow_call:
+    inputs: &reusable_inputs
       runner:
         type: string
         default: 'ubuntu-latest'
@@ -279,7 +279,7 @@ jobs:
       id-token: write      # PyPI upload via "trusted publishing", and GH attestation
       attestations: write  # GH attestation
       contents: write      # autorelease repository changes
-      actions: write       # GH pages workflow-dispatch
+      actions: write       # GH pages build
     
     steps:
       
@@ -383,11 +383,8 @@ jobs:
         with:
           packages-dir: dist/  # the default
       
-      # TODO change to reusable workflow call
       - name: Trigger GH Pages rebuild
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: gh_pages.yaml  # takes no inputs
+        uses: ./.github/workflows/gh_pages.yaml  # takes no inputs
   
   
   conda_trigger:
@@ -397,18 +394,12 @@ jobs:
     
     steps:
       - name: Trigger conda pypdfium2_helpers build
-        uses: benc-uk/workflow-dispatch@v1
+        uses: ./.github/workflows/conda.yaml
         with:
-          workflow: conda.yaml
-          inputs: |
-            {
-              "package": "helpers",
-              "pdfium_ver": "latest",
-              "new_only": "false",
-              "test": "true",
-              "publish": "${{ inputs.publish }}",
-              "py_ver": "${{ inputs.py_ver }}"
-            }
+          package: helpers
+          test: true
+          publish: ${{ inputs.publish }}
+          py_ver: ${{ inputs.py_ver }}
   
   
   cleanup:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -379,6 +379,7 @@ jobs:
         with:
           packages-dir: dist/  # the default
       
+      # TODO change to reusable workflow call
       - name: Trigger GH Pages rebuild
         uses: benc-uk/workflow-dispatch@v1
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,11 +10,9 @@ on:
       runner:
         type: string
         default: 'ubuntu-latest'
-        # required: true
       py_ver:
         type: string
         default: '3.14'
-        # required: true
       test:
         type: boolean
         default: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,26 +5,30 @@
 
 name: Main packaging
 on:
-  workflow_dispatch:
+  workflow_call: &reusable_inputs
     inputs:
-      test:
-        default: true
-        type: boolean
-      augment:
-        default: false
-        type: boolean
-      publish:
-        default: false
-        type: boolean
-      conda:
-        default: false
-        type: boolean
-      py_ver:
-        default: '3.14'
-        type: string
       runner:
-        default: 'ubuntu-latest'
         type: string
+        default: 'ubuntu-latest'
+        required: true
+      py_ver:
+        type: string
+        default: '3.14'
+        required: true
+      test:
+        type: boolean
+        default: true
+      augment:
+        type: boolean
+        default: false
+      publish:
+        type: boolean
+        default: false
+      conda:
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs: *reusable_inputs
 
 defaults:
   run:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,11 +10,11 @@ on:
       runner:
         type: string
         default: 'ubuntu-latest'
-        required: true
+        # required: true
       py_ver:
         type: string
         default: '3.14'
-        required: true
+        # required: true
       test:
         type: boolean
         default: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -394,7 +394,7 @@ jobs:
       package: helpers
       test: true
       publish: ${{ inputs.publish }}
-      py_ver: ${{ inputs.py_ver }}
+      # py_ver: ${{ inputs.py_ver }}  # temporarily downgraded
   
   
   cleanup:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -380,33 +380,25 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/  # the default
-      
-      # here we already have the repo, so using local workflow will work
-      - name: Trigger GH Pages rebuild
-        uses: ./.github/workflows/gh_pages.yaml  # takes no inputs
   
+  gh_pages:
+    needs: publish
+    if: ${{ inputs.publish && !cancelled() && !contains(needs.*.result, 'failure') }}
+    uses: ./.github/workflows/gh_pages.yaml  # takes no inputs
   
-  conda_trigger:
+  conda:
     needs: publish  # i.e. goes after, regardless if publish is active or not
     if: ${{ inputs.conda && !cancelled() && !contains(needs.*.result, 'failure') }}
-    runs-on: ${{ inputs.runner }}
-    
-    steps:
-      
-      - name: Check out repo to run local workflow
-        uses: actions/checkout@v6
-      
-      - name: Trigger conda pypdfium2_helpers build
-        uses: ./.github/workflows/conda.yaml
-        with:
-          package: helpers
-          test: true
-          publish: ${{ inputs.publish }}
-          py_ver: ${{ inputs.py_ver }}
+    uses: ./.github/workflows/conda.yaml
+    with:
+      package: helpers
+      test: true
+      publish: ${{ inputs.publish }}
+      py_ver: ${{ inputs.py_ver }}
   
   
   cleanup:
-    needs: [publish, conda_trigger]
+    needs: [publish, gh_pages, conda]
     if: ${{ !cancelled() }}
     runs-on: ${{ inputs.runner }}
     

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -393,7 +393,7 @@ jobs:
     uses: ./.github/workflows/conda.yaml
     with:
       package: helpers
-      test: true
+      test: ${{ inputs.test }}
       publish: ${{ inputs.publish }}
       # py_ver: ${{ inputs.py_ver }}  # temporarily downgraded
   

--- a/.github/workflows/sbuild_one.yaml
+++ b/.github/workflows/sbuild_one.yaml
@@ -12,6 +12,7 @@ on:
       py_ver:
         type: string
         default: '3.14'
+        required: true
       target_cpu:
         type: string
         default: ''

--- a/.github/workflows/sbuild_one.yaml
+++ b/.github/workflows/sbuild_one.yaml
@@ -41,7 +41,7 @@ jobs:
   
   build:
     runs-on: ${{ inputs.os }}
-    if: ${{ inputs.condition || inputs.condition == '' }}
+    if: ${{ inputs.condition }}
     
     steps:
       

--- a/.github/workflows/sbuild_one.yaml
+++ b/.github/workflows/sbuild_one.yaml
@@ -5,11 +5,13 @@ name: Sourcebuild One
 
 on:
   workflow_call:
-    inputs:
+    inputs: &reusable_inputs
       os:
         type: string
+        required: true
       py_ver:
         type: string
+        default: '3.14'
       target_cpu:
         type: string
         default: ''
@@ -29,28 +31,7 @@ on:
         type: boolean
         default: true
   workflow_dispatch:
-    inputs:
-      os:
-        type: string
-        default: ubuntu-latest
-      py_ver:
-        type: string
-        default: '3.14'
-      target_cpu:
-        type: string
-        default: ''
-      target_os:
-        type: string
-        default: ''
-      tag:
-        type: string
-        default: ''
-      branch:
-        type: string
-        default: ''
-      repo_tag:
-        type: string
-        default: ''
+    inputs: *reusable_inputs
 
 defaults:
   run:

--- a/.github/workflows/sbuild_one.yaml
+++ b/.github/workflows/sbuild_one.yaml
@@ -12,7 +12,6 @@ on:
       py_ver:
         type: string
         default: '3.14'
-        # required: true
       target_cpu:
         type: string
         default: ''

--- a/.github/workflows/sbuild_one.yaml
+++ b/.github/workflows/sbuild_one.yaml
@@ -12,7 +12,7 @@ on:
       py_ver:
         type: string
         default: '3.14'
-        required: true
+        # required: true
       target_cpu:
         type: string
         default: ''

--- a/.github/workflows/sbuild_one_native.yaml
+++ b/.github/workflows/sbuild_one_native.yaml
@@ -12,11 +12,9 @@ on:
       compiler:
         type: string
         default: gcc
-        # required: true
       py_ver:
         type: string
         default: '3.14'
-        # required: true
       pdfium_ver:
         type: string
         default: ''

--- a/.github/workflows/sbuild_one_native.yaml
+++ b/.github/workflows/sbuild_one_native.yaml
@@ -12,12 +12,14 @@ on:
       compiler:
         type: string
         default: gcc
-      pdfium_ver:
-        type: string
-        default: ''
+        required: true
       py_ver:
         type: string
         default: '3.14'
+        required: true
+      pdfium_ver:
+        type: string
+        default: ''
       vendor:
         type: string
         default: 'icu'

--- a/.github/workflows/sbuild_one_native.yaml
+++ b/.github/workflows/sbuild_one_native.yaml
@@ -5,9 +5,10 @@ name: Sourcebuild One Native
 
 on:
   workflow_call:
-    inputs:
+    inputs: &reusable_inputs
       os:
         type: string
+        required: true
       compiler:
         type: string
         default: gcc
@@ -27,28 +28,7 @@ on:
         type: boolean
         default: true
   workflow_dispatch:
-    inputs:
-      os:
-        type: string
-        default: ubuntu-latest
-      compiler:
-        type: choice
-        default: gcc
-        options:
-          - gcc
-          - clang
-      pdfium_ver:
-        type: string
-        default: ''
-      py_ver:
-        type: string
-        default: '3.14'
-      vendor:
-        type: string
-        default: 'icu'
-      test_pdfium:
-        type: boolean
-        default: true
+    inputs: *reusable_inputs
 
 defaults:
   run:

--- a/.github/workflows/sbuild_one_native.yaml
+++ b/.github/workflows/sbuild_one_native.yaml
@@ -12,11 +12,11 @@ on:
       compiler:
         type: string
         default: gcc
-        required: true
+        # required: true
       py_ver:
         type: string
         default: '3.14'
-        required: true
+        # required: true
       pdfium_ver:
         type: string
         default: ''

--- a/.github/workflows/sbuild_one_native.yaml
+++ b/.github/workflows/sbuild_one_native.yaml
@@ -38,7 +38,7 @@ jobs:
   
   build:
     runs-on: ${{ inputs.os }}
-    if: ${{ inputs.condition || inputs.condition == '' }}
+    if: ${{ inputs.condition }}
     
     steps:
       

--- a/.github/workflows/trigger_conda_raw.yaml
+++ b/.github/workflows/trigger_conda_raw.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-name: Trigger conda_raw release
+name: Run conda_raw release
 on:
   schedule:
     # pdfium-binaries triggers conda on the first Monday of month at 4 o'clock UTC, so we'll want to rebuild after that, but before the next main release where we want to use the package
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  trigger:
+  conda_raw_release:
     uses: ./.github/workflows/conda.yaml
     with:
       package: raw

--- a/.github/workflows/trigger_conda_raw.yaml
+++ b/.github/workflows/trigger_conda_raw.yaml
@@ -15,15 +15,9 @@ jobs:
     
     steps:
       - name: Trigger
-        uses: benc-uk/workflow-dispatch@v1
+        uses: ./.github/workflows/conda.yaml
         with:
-          workflow: conda.yaml
-          inputs: |
-            {
-              "package": "raw",
-              "pdfium_ver": "latest",
-              "new_only": "true",
-              "test": "true",
-              "publish": "true",
-              "py_ver": "3.14"
-            }
+          package: raw
+          new_only: true
+          test: true
+          # publish: true  # XXX temporarily commented out

--- a/.github/workflows/trigger_conda_raw.yaml
+++ b/.github/workflows/trigger_conda_raw.yaml
@@ -9,19 +9,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  
   trigger:
-    runs-on: ubuntu-latest
-    
-    steps:
-      
-      - name: Check out repo to run local workflow
-        uses: actions/checkout@v6
-      
-      - name: Trigger
-        uses: ./.github/workflows/conda.yaml
-        with:
-          package: raw
-          new_only: true
-          test: true
-          # publish: true  # XXX temporarily commented out
+    uses: ./.github/workflows/conda.yaml
+    with:
+      package: raw
+      new_only: true
+      test: true
+      # publish: true  # XXX temporarily commented out

--- a/.github/workflows/trigger_conda_raw.yaml
+++ b/.github/workflows/trigger_conda_raw.yaml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      
+      - name: Check out repo to run local workflow
+        uses: actions/checkout@v6
+      
       - name: Trigger
         uses: ./.github/workflows/conda.yaml
         with:

--- a/.github/workflows/trigger_conda_raw.yaml
+++ b/.github/workflows/trigger_conda_raw.yaml
@@ -15,4 +15,4 @@ jobs:
       package: raw
       new_only: true
       test: true
-      # publish: true  # XXX temporarily commented out
+      publish: true

--- a/.github/workflows/trigger_main.yaml
+++ b/.github/workflows/trigger_main.yaml
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2026 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-# Separate trigger workflow because schedule uses default inputs, and clearly we don't want publish enabled by default
+# Separate workflow because schedule uses default inputs, and clearly we don't want publish enabled by default
 
-name: Trigger main release
+name: Run main release
 on:
   # NOTE Schedule currently suspended, to preserve PyPI disk space. Manually dispatch releases as needed.
   # # https://github.com/bblanchon/pdfium-binaries/blob/master/.github/workflows/trigger.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  trigger:
+  run_main_release:
     uses: ./.github/workflows/main.yaml
     with:
       test: true

--- a/.github/workflows/trigger_main.yaml
+++ b/.github/workflows/trigger_main.yaml
@@ -14,19 +14,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  
   trigger:
-    runs-on: ubuntu-latest
-    
-    steps:
-      
-      - name: Check out repo to run local workflow
-        uses: actions/checkout@v6
-      
-      - name: Trigger
-        uses: ./.github/workflows/main.yaml
-        with:
-          test: true
-          augment: true
-          conda: true
-          # publish: true  # XXX temporarily commented out
+    uses: ./.github/workflows/main.yaml
+    with:
+      test: true
+      augment: true
+      conda: true
+      # publish: true  # XXX temporarily commented out

--- a/.github/workflows/trigger_main.yaml
+++ b/.github/workflows/trigger_main.yaml
@@ -21,4 +21,4 @@ jobs:
       augment: true
       gh_pages: true
       conda: true
-      # publish: true  # XXX temporarily commented out
+      publish: true

--- a/.github/workflows/trigger_main.yaml
+++ b/.github/workflows/trigger_main.yaml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      
+      - name: Check out repo to run local workflow
+        uses: actions/checkout@v6
+      
       - name: Trigger
         uses: ./.github/workflows/main.yaml
         with:

--- a/.github/workflows/trigger_main.yaml
+++ b/.github/workflows/trigger_main.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 geisserml <geisserml@gmail.com>
 # SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-# Separate trigger workflow because we can't configure inputs for scheduled workflow runs (and don't want publish enabled by default in the main workflow)
+# Separate trigger workflow because schedule uses default inputs, and clearly we don't want publish enabled by default
 
 name: Trigger main release
 on:
@@ -20,15 +20,9 @@ jobs:
     
     steps:
       - name: Trigger
-        uses: benc-uk/workflow-dispatch@v1
+        uses: ./.github/workflows/main.yaml
         with:
-          workflow: main.yaml
-          inputs: |
-            {
-              "test": "true",
-              "augment": "true",
-              "publish": "true",
-              "conda": "true",
-              "py_ver": "3.14",
-              "runner": "ubuntu-latest"
-            }
+          test: true
+          augment: true
+          conda: true
+          # publish: true  # XXX temporarily commented out

--- a/.github/workflows/trigger_main.yaml
+++ b/.github/workflows/trigger_main.yaml
@@ -19,5 +19,6 @@ jobs:
     with:
       test: true
       augment: true
+      gh_pages: true
       conda: true
       # publish: true  # XXX temporarily commented out

--- a/src/pypdfium2/_helpers/page.py
+++ b/src/pypdfium2/_helpers/page.py
@@ -376,7 +376,9 @@ class PdfPage (pdfium_i.AutoCloseable):
                 Additional rotation in degrees (0, 90, 180, or 270).
             
             crop (tuple[float, float, float, float]):
-                Amount in PDF canvas units to cut off from page borders (left, bottom, right, top). Crop is applied after rotation.
+                Amount in PDF canvas units to cut off from page borders (left, bottom, right, top).
+                Negative crop may extend rendering beyond the default clipping area.
+                Rendering crop applies on bitmap level (i.e. after rotation), unlike changing the page cropbox using :meth:`.set_cropbox`.
             
             may_draw_forms (bool):
                 If True, render form fields (provided the document has forms and :meth:`~.PdfDocument.init_forms` was called).


### PR DESCRIPTION
Unfortunately, GH YAML anchors are weak (due to lack of support for merge keys), see this excellent blog post:
https://frenck.dev/github-actions-yaml-anchors-aliases-merge-keys/

but still, it might be acceptable for our purposes.