### PR TITLE
fix: memleak when a page is retrieved from a document with an active form environment and objects are auto-closed

### DIFF
--- a/docs/devel/changelog_staging.md
+++ b/docs/devel/changelog_staging.md
@@ -4,6 +4,7 @@
 <!-- List character: dash (-) -->
 
 # Changelog for next release
+- Fixed a memory leak with form environments: `PdfDocument.formenv` and the formenv's finalizer state referenced each other, rooting the document <-> formenv reference cycle in the global `weakref.finalize` registry, so that it could never be garbage collected. Also, `PdfPage`'s finalizer state held strong references to formenv/document, which (due to GC generation promotion) could delay their collection indefinitely. Finalizer states now hold parents weakly; correct child-before-parent teardown order in the GC case is ensured by sharing mutable raw-handle holders between the finalizers of document, formenv and pages, so whichever runs first takes over pending teardown work in due order. Explicit `close()` calls behave as before, and remain recommended for deterministic resource release.
 - Updated `build_toolchained.py` from PDFium `7191` to `7880`. Despite the gap, this turned out fairly straightforward.
 - Updated `build_native.py` from PDFium `7841` to `7880` (see below for more info).
   Added patch to fix a build system issue introduced upstream.

--- a/src/pypdfium2/_helpers/document.py
+++ b/src/pypdfium2/_helpers/document.py
@@ -68,16 +68,18 @@ class PdfDocument (pdfium_i.AutoCloseable):
         self._autoclose = autoclose
         self._data_holder = []
         self._data_closer = []
+        self._formenv_holder = []
+        self._page_holders = []
         self.formenv = None
-        
+
         if isinstance(self._input, pdfium_c.FPDF_DOCUMENT):
             self.raw = self._input
         else:
             self.raw, to_hold, to_close = _open_pdf(self._input, self._password, self._autoclose)
             self._data_holder += to_hold
             self._data_closer += to_close
-        
-        super().__init__(PdfDocument._close_impl, self._data_holder, self._data_closer, tracked=False)
+
+        super().__init__(PdfDocument._close_impl, self._data_holder, self._data_closer, self._formenv_holder, self._page_holders, tracked=False)
     
     
     # Support using PdfDocument in a with-block
@@ -108,7 +110,21 @@ class PdfDocument (pdfium_i.AutoCloseable):
     
     
     @staticmethod
-    def _close_impl(raw, data_holder, data_closer):
+    def _close_impl(raw, data_holder, data_closer, formenv_holder, page_holders):
+        # Pages or formenv may not have been closed in due order before the document: when document, formenv and pages are reclaimed in the same GC run, finalizer order is not guaranteed. Take over any pending teardown now, before closing the document.
+        for holder in page_holders:
+            if holder:
+                if formenv_holder:
+                    pdfium_c.FORM_OnBeforeClosePage(holder[0], formenv_holder[0])
+                pdfium_c.FPDF_ClosePage(holder[0])
+                holder.clear()
+
+        page_holders.clear()
+        
+        if formenv_holder:
+            pdfium_c.FPDFDOC_ExitFormFillEnvironment(formenv_holder[0])
+            formenv_holder.clear()
+
         pdfium_c.FPDF_CloseDocument(raw)
         for data in data_holder:
             id(data)
@@ -173,6 +189,9 @@ class PdfDocument (pdfium_i.AutoCloseable):
         raw = pdfium_c.FPDFDOC_InitFormFillEnvironment(self, config)
         if not raw:
             raise PdfiumError(f"Initializing form env failed for document {self}.")
+        
+        assert not self._formenv_holder
+        self._formenv_holder += (raw, config)
         self.formenv = PdfFormEnv(raw, self, config)
         self._add_kid(self.formenv)
         
@@ -572,21 +591,37 @@ class PdfFormEnv (pdfium_i.AutoCloseable):
             Parent document this form env belongs to.
     """
     
+    # The finalizer state must not hold strong references to the parent document: pdf.formenv points back to this object, so a strong reference from the finalizer state (args or owner) would root the document <-> formenv reference cycle in the global finalizer registry, making it immortal (memory leak).
+    # Consequently, child-before-parent finalization order is not guaranteed when document, formenv and pages are reclaimed in the same GC run. pdf._formenv_holder keeps raw/config alive as long as needed, and tells whichever close function runs first whether the form env still needs to be exited (same for pages, cf. PdfPage).
+    _WEAK_PARENT = True
+
     def __init__(self, raw, pdf, config):
         self.raw = raw
         self.pdf = pdf
         self.config = config
-        super().__init__(PdfFormEnv._close_impl, self.config, self.pdf)
-    
+        super().__init__(PdfFormEnv._close_impl, pdf._formenv_holder, pdf._page_holders, pdf._wref_to_self)
+
     @property
     def parent(self):  # AutoCloseable hook
         return self.pdf
-    
+
     @staticmethod
-    def _close_impl(raw, config, pdf):
-        pdfium_c.FPDFDOC_ExitFormFillEnvironment(raw)
-        id(config)
-        pdf.formenv = None
+    def _close_impl(raw, formenv_holder, page_holders, pdf_wref):
+        if formenv_holder:
+            # close pending pages first (only relevant in the GC same-run case, where the page helpers are necessarily dead already - live pages keep the document, and thus the formenv, alive)
+            for holder in page_holders:
+                if holder:
+                    pdfium_c.FORM_OnBeforeClosePage(holder[0], raw)
+                    pdfium_c.FPDF_ClosePage(holder[0])
+                    holder.clear()
+                    
+            pdfium_c.FPDFDOC_ExitFormFillEnvironment(raw)
+            formenv_holder.clear()
+
+        pdf = pdf_wref()
+
+        if pdf is not None:
+            pdf.formenv = None
 
 
 class PdfXObject (pdfium_i.AutoCloseable):

--- a/src/pypdfium2/_helpers/page.py
+++ b/src/pypdfium2/_helpers/page.py
@@ -32,18 +32,34 @@ class PdfPage (pdfium_i.AutoCloseable):
             Formenv handle, if the parent pdf had an active formenv at the time of page retrieval. None otherwise.
     """
     
+    # The finalizer state must not hold strong references to the parent document or formenv, which would delay (or, with the formenv's backref cycle, entirely prevent) their garbage collection - see PdfFormEnv.
+    # Instead, mutable holders of raw handles are shared between the finalizers of page, formenv and document, so that whichever runs first can take over pending teardown work in due order.
+    _WEAK_PARENT = True
+
     def __init__(self, raw, pdf, formenv):
         self.raw = raw
         self.pdf = pdf
         self.formenv = formenv
-        super().__init__(PdfPage._close_impl, self.formenv)
-    
-    
+
+        # prune holders of closed pages, so the list does not grow unboundedly over a document's lifetime
+        pdf._page_holders[:] = [h for h in pdf._page_holders if h]
+        holder = [raw]
+        pdf._page_holders.append(holder)
+
+        super().__init__(PdfPage._close_impl, pdf._formenv_holder if formenv else None, holder)
+
+
     @staticmethod
-    def _close_impl(raw, formenv):
-        if formenv:
-            pdfium_c.FORM_OnBeforeClosePage(raw, formenv)
+    def _close_impl(raw, formenv_holder, holder):
+        if not holder:
+            return  # page was already closed by the formenv's or document's finalizer (GC same-run case)
+        
+        if formenv_holder:
+            # formenv_holder being empty means the formenv was already exited (GC same-run case); skip FORM_OnBeforeClosePage() then, as the page views have been torn down along with the formenv
+            pdfium_c.FORM_OnBeforeClosePage(raw, formenv_holder[0])
+            
         pdfium_c.FPDF_ClosePage(raw)
+        holder.clear()
     
     
     @property

--- a/src/pypdfium2/internal/bases.py
+++ b/src/pypdfium2/internal/bases.py
@@ -76,8 +76,13 @@ def _close_template(info, owner):
         return
     
     assert info.state != _STATE.INVALID
-    
+
     parent = owner.parent
+
+    if isinstance(parent, weakref.ref):
+        # _WEAK_PARENT - may be None if the parent is dead or trash in the same GC run
+        parent = parent()
+
     if parent is not None:
         assert not parent._tree_closed()
         if info.tracked:
@@ -103,7 +108,12 @@ class AutoCastable:
 
 
 class AutoCloseable (AutoCastable):
-    
+
+    # If True, the finalizer state holds the parent via weakref rather than a strong reference.
+    # This must be set for objects the parent strongly references back (e.g. document <-> formenv): otherwise, the global finalizer registry would root the resulting reference cycle, so that it could never be garbage collected.
+    # The price is that child-before-parent finalization order is not guaranteed anymore when both objects are reclaimed in the same GC run, so the parent's close function must be able to handle the child's cleanup if it runs first (cf. PdfDocument/PdfFormEnv._close_impl).
+    _WEAK_PARENT = False
+
     def __init__(self, close_func, *args, obj=None, needs_free=True, tracked=True, **kwargs):
         
         # proactively prevent accidental double initialization
@@ -133,7 +143,12 @@ class AutoCloseable (AutoCastable):
         own_type = type(self)
         # note, this captures the object's parent, repr and so on at finalizer installation time
         # in case they ever change, we'd have to store the owner in an attribute and update it
-        owner = _FinalizerOwner(self.raw, self.parent, self._wref_to_self, own_type, repr(self))
+        parent = self.parent
+        
+        if self._WEAK_PARENT and parent is not None:
+            parent = parent._wref_to_self
+            
+        owner = _FinalizerOwner(self.raw, parent, self._wref_to_self, own_type, repr(self))
         self._finalizer = weakref.finalize(self._fin_obj, _close_template, self._fin_info, owner)
         ObjectTracker[own_type].add(self._wref_to_self)
     

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -4,8 +4,11 @@
 # TODO test formenv and page deletion
 
 import re
+import gc
 import ctypes
 import pathlib
+import weakref
+import itertools
 import pytest
 from .conftest import TestFiles
 
@@ -251,3 +254,90 @@ def test_post_close():
     pdf.close()
     with pytest.raises(ctypes.ArgumentError):
         pdf.get_version()
+
+
+def test_formenv_gc_collectable():
+    # Regression test: document and formenv reference each other, so they can only be reclaimed by the cyclic GC. The finalizer state must not root them in the global finalizer registry, otherwise they would never be collected (memory leak).
+    pdf = pdfium.PdfDocument(TestFiles.forms)
+    pdf.init_forms()
+    assert pdf.formenv is not None
+    page = pdf[0]
+
+    pdf_ref, formenv_ref, page_ref = weakref.ref(pdf), weakref.ref(pdf.formenv), weakref.ref(page)
+    del pdf, page
+    gc.collect()
+
+    assert pdf_ref() is None
+    assert formenv_ref() is None
+    assert page_ref() is None
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(["page", "formenv", "pdf"])))
+def test_formenv_teardown_takeover_any_order(order):
+
+    # Simulate the GC same-run case, where the finalizer order between document, formenv and pages is not guaranteed: whichever close function runs first shall take over pending teardown work in due order, and the remaining calls shall degrade to no-ops.
+
+    pdf = pdfium.PdfDocument(TestFiles.forms)
+    pdf.init_forms()
+    formenv = pdf.formenv
+    page = pdf[0]
+
+    # detach the finalizers and invoke the close functions by hand in the given order
+    for obj in (pdf, formenv, page):
+        obj._detach_finalizer()
+
+    holder = pdf._page_holders[-1]
+    impls = dict(
+        pdf = lambda: pdfium.PdfDocument._close_impl(pdf.raw, pdf._data_holder, pdf._data_closer, pdf._formenv_holder, pdf._page_holders),
+        formenv = lambda: pdfium.PdfFormEnv._close_impl(formenv.raw, pdf._formenv_holder, pdf._page_holders, pdf._wref_to_self),
+        page = lambda: pdfium.PdfPage._close_impl(page.raw, pdf._formenv_holder, holder),
+    )
+    for key in order:
+        impls[key]()
+
+    assert not holder
+    assert not pdf._formenv_holder
+    assert pdf.formenv is None
+
+
+def test_formenv_close_and_reinit():
+
+    pdf = pdfium.PdfDocument(TestFiles.forms)
+    pdf.init_forms()
+    formenv = pdf.formenv
+    page = pdf[0]
+
+    # closing the formenv implicitly closes pages retrieved through it, and resets pdf.formenv
+    formenv.close()
+    assert formenv.raw is None and page.raw is None
+    assert pdf.formenv is None and not pdf._formenv_holder
+
+    # forms can be re-initialized afterwards
+    pdf.init_forms()
+    assert pdf.formenv is not None
+    page = pdf[0]
+    page.render(may_draw_forms=True)
+    pdf.close()
+    assert pdf.formenv is None
+
+
+def test_page_gc_with_live_formenv():
+
+    # Pages may be reclaimed by GC while document and formenv stay alive and usable.
+
+    pdf = pdfium.PdfDocument(TestFiles.forms)
+    pdf.init_forms()
+
+    for _ in range(3):
+        page = pdf[0]
+        page_ref = weakref.ref(page)
+        del page
+        gc.collect()
+        assert page_ref() is None
+
+    # holders of closed pages are pruned on page retrieval
+    page = pdf[0]
+    assert len(pdf._page_holders) <= 2
+
+    page.render(may_draw_forms=True)
+    pdf.close()


### PR DESCRIPTION
## Description

Fixes #444 — memory leak when a document with an active form environment is reclaimed by GC instead of being closed via `close()` explicitly (~18 kB per document/page in the linked repro, unbounded growth).

_Note: Assisted by Claude._

### Root cause

Two layers, both in the autoclose machinery's interaction with the global `weakref.finalize` registry:

1. **Immortal reference cycle**: `PdfFormEnv`'s finalizer state (the finalize `args` and `_FinalizerOwner.parent`) held strong references to the parent `PdfDocument`, while `pdf.formenv` points back at the formenv. Since the finalize registry is a GC root and its entry is only released when the finalizer runs, the document <-> formenv pair was permanently reachable and **never collected at all** — the exact anti-pattern the `weakref.finalize` docs warn about (and which `_close_template`'s comment already quotes). Verified empirically: after a forced `gc.collect()`, all documents from a loop were still alive. With a page loaded, each immortal document additionally retains its parsed page cache, hence the leak size.

2. **GC generation promotion**: even with (1) fixed, `PdfPage`'s finalizer args held the formenv strongly, so the document/formenv pair only became garbage one GC pass *after* the page's collection — by which point CPython (tested on 3.13) had usually promoted them to an older generation that effectively never gets collected in a steady-state workload. Still unbounded growth in practice.

### Fix

- New `AutoCloseable._WEAK_PARENT` opt-in (`internal/bases.py`): the finalizer state holds the parent via weakref. Set for `PdfFormEnv` and `PdfPage`.
- Holding parents weakly forfeits the guaranteed child-before-parent finalization order when document, formenv and pages are reclaimed in the same GC run. To compensate, mutable raw-handle holders (`PdfDocument._formenv_holder`, `._page_holders`) are shared between the finalizers of document, formenv and pages: whichever close function runs first takes over pending teardown work in due order (`FORM_OnBeforeClosePage` -> `FPDF_ClosePage` -> `FPDFDOC_ExitFormFillEnvironment` -> `FPDF_CloseDocument`), and the remaining calls degrade to no-ops.
- Liveness guarantees for *live* helper objects are unchanged (instance attributes like `page.pdf`, `page.formenv`, `formenv.pdf` remain strong refs), and explicitly `close()`d objects behave exactly as before (kids-walk order preserved).

### Verification

- Repro from #444: `NOCLOSE` went from **+53 MB (unbounded)** to bounded behavior matching the no-forms baseline over 20k iterations; live object counts oscillate as GC reclaims them instead of growing monotonically.
- Full test suite passes. New tests: GC collectability regression test, all six manual orderings of the three close functions (takeover logic), explicit `formenv.close()` + re-`init_forms()`, page GC while document/formenv stay alive and usable.
- Worst-case ordering was also observed live via `DEBUG_AUTOCLOSE`: in a real GC group death the *document's* finalizer fired first and correctly performed the whole teardown.


## Checklist

<!--
- Use the Preview tab to see how the PR will render.
- Answer the questions below, choosing the section(s) relevant to your PR. Non-applying sections shall be set to `closed`.
- Place an `x` in the [ ] for yes, leave it empty for no. If a question is not applicable, remove the [ ], but keep the message in place.
-->

<details open><summary>Helpers</summary>

- [x] This PR changes helpers code.
- [x] The change comes with sufficient test cases to confirm correct functionality.
- [ ] Any new test files are under a suitable license and have been registered in `REUSE.toml`.

</details>
<details close><summary>Setup</summary>

- [ ] This PR changes setup code (`setupsrc/`, `setup.py` etc.).
- [ ] I have at least skimmed through [Installation -> With setup][1] and subsections.
- [ ] I have tested the change does not break internal callers.
- [ ] I believe the change is maintainable and does not cause unreasonable complexity or code fragmentation.
- [ ] The change does not shift a maintenance burden or upstream downstream tasks. *Keep handlers generic, avoid overly downstream-specific or (for us) effectively dead code passages.*
- [ ] I have assessed that the targeted use case cannot reasonably be satisfied by existing means, such as [Caller-provided data files][2], or the change forms a notable improvement over possible alternatives.
- [ ] I believe the targeted use case is supported by pypdfium2-team. *Note that we may not want to support esoteric or artificially restricted setup envs.*

</details>
<details open><summary>Other</summary>

- [x] This PR changes other things, namely: internal autoclose machinery (`internal/bases.py`: `_WEAK_PARENT` opt-in)

</details>

[1]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#from-the-repository--with-setup
[2]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#with-caller-provided-data-files
