### PR TITLE
release: rename provenance file to pypdfium2.sigstore.json

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -392,7 +392,7 @@ jobs:
           subject-path: 'dist/*, gh_only/*'
       
       - name: Rename provenance file
-        run: mv "$SRC_PATH" pypdfium2-attestation.json
+        run: mv "$SRC_PATH" pypdfium2.sigstore.json
         env:
           SRC_PATH: ${{ steps.provenance.outputs.bundle-path }}
       
@@ -401,7 +401,7 @@ jobs:
         uses: ncipollo/release-action@v1  # TODO pin to hash?
         with:
           immutableCreate: true
-          artifacts: 'dist/*.whl,gh_only/*.whl,dist/*.tar.gz,pypdfium2-attestation.json'
+          artifacts: 'dist/*.whl,gh_only/*.whl,dist/*.tar.gz,pypdfium2.sigstore.json'
           bodyFile: 'RELEASE.md'
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.build.outputs.new_version }}


### PR DESCRIPTION


**Important:** External contributors are required to comply with the template.

<!--
STOP! IF THE PATCH YOU ARE ABOUT TO SUBMIT WAS MADE WITH AI, DISCARD IT AND SHOW YOURSELF OUT!

If you did not use AI, welcome! Please read the points below.
- Use the Preview tab to see how the PR will render.
- Answer the questions below, choosing the section(s) relevant to your PR. Non-applying sections shall be set to `closed`.
- Place an `x` in the [ ] for yes, leave it empty for no. If a question is not applicable, remove the [ ], but keep the message in place.
-->

## Description

Per https://github.com/actions/attest#outputs, the attestation file format is JSON serialized Sigstore bundle, and .sigstore.json is the conventional filename extension for those files.

Refs https://github.com/UpCloudLtd/upcloud-cli/issues/788#issuecomment-4688907615

## Checklist

- [x] I understand that **AI pull requests are banned** from this project. *PRs that show typical characteristics of AI will be closed immediately and the reporter may be blocked.*

<details open><summary>Helpers</summary>

- [ ] This PR changes helpers code.
- [ ] The change comes with sufficient test cases to confirm correct functionality.
- [ ] Any new test files are under a suitable license and have been registered in `REUSE.toml`.

</details>
<details open><summary>Setup</summary>

- [ ] This PR changes setup code (`setupsrc/`, `setup.py` etc.).
- [ ] I have at least skimmed through [Installation -> With setup][1] and subsections.
- [ ] I have tested the change does not break internal callers.
- [x] I believe the change is maintainable and does not cause unreasonable complexity or code fragmentation.
- [ ] The change does not shift a maintenance burden or upstream downstream tasks. *Keep handlers generic, avoid overly downstream-specific or (for us) effectively dead code passages.*
- [ ] I have assessed that the targeted use case cannot reasonably be satisfied by existing means, such as [Caller-provided data files][2], or the change forms a notable improvement over possible alternatives.
- [ ] I believe the targeted use case is supported by pypdfium2-team. *Artificially restricted setup envs are not officially supported, e.g. offline setup (for offline installation, use wheels).*

</details>
<details open><summary>Other</summary>

- [ ] This PR changes other things, namely: ... <!-- sum up change (keyword/topic) -->

</details>

[1]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#from-the-repository--with-setup
[2]: https://github.com/pypdfium2-team/pypdfium2?tab=readme-ov-file#with-caller-provided-data-files
