### PR TITLE
Rebase bigendian patch for pdfium 7913

### DIFF
--- a/patches/bigendian.patch
+++ b/patches/bigendian.patch
@@ -29,30 +29,30 @@ index 30a7e24..eea5215 100644
    EXPECT_EQ(4u, buffer.GetLength());
    EXPECT_EQ(0x21u, buffer.GetSpan()[0]);
 diff --git a/core/fxcrt/cfx_seekablestreamproxy.cpp b/core/fxcrt/cfx_seekablestreamproxy.cpp
-index c358401..c01cfd0 100644
+index f0b4143..b6e1355 100644
 --- a/core/fxcrt/cfx_seekablestreamproxy.cpp
 +++ b/core/fxcrt/cfx_seekablestreamproxy.cpp
-@@ -89,11 +89,19 @@ void SwapByteOrder(pdfium::span<uint16_t> str) {
- 
- }  // namespace
- 
+@@ -91,11 +91,19 @@ void SwapByteOrder(pdfium::span<uint16_t> str) {
+ // Returns the code page indicated by a byte-order mark at the start of a
+ // stream, or nullopt if no BOM is present.
+ std::optional<FX_CodePage> DetectByteOrderMark(uint32_t leading_bytes) {
 +#if defined(ARCH_CPU_LITTLE_ENDIAN)
- #define BOM_UTF8_MASK 0x00FFFFFF
- #define BOM_UTF8 0x00BFBBEF
- #define BOM_UTF16_MASK 0x0000FFFF
- #define BOM_UTF16_BE 0x0000FFFE
- #define BOM_UTF16_LE 0x0000FEFF
+   constexpr uint32_t kUtf8Mask = 0x00FFFFFF;
+   constexpr uint32_t kUtf8Marker = 0x00BFBBEF;
+   constexpr uint32_t kUtf16Mask = 0x0000FFFF;
+   constexpr uint32_t kUtf16BeMarker = 0x0000FFFE;
+   constexpr uint32_t kUtf16LeMarker = 0x0000FEFF;
 +#else
-+#define BOM_UTF8_MASK 0xFFFFFF00
-+#define BOM_UTF8 0xEFBBBF00
-+#define BOM_UTF16_MASK 0xFFFF0000
-+#define BOM_UTF16_BE 0xFEFF0000
-+#define BOM_UTF16_LE 0xFFFE0000
++  constexpr uint32_t kUtf8Mask = 0xFFFFFF00;
++  constexpr uint32_t kUtf8Marker = 0xEFBBBF00;
++  constexpr uint32_t kUtf16Mask = 0xFFFF0000;
++  constexpr uint32_t kUtf16BeMarker = 0xFEFF0000;
++  constexpr uint32_t kUtf16LeMarker = 0xFFFE0000;
 +#endif
  
- CFX_SeekableStreamProxy::CFX_SeekableStreamProxy(
-     const RetainPtr<IFX_SeekableReadStream>& stream)
-@@ -188,9 +196,15 @@ size_t CFX_SeekableStreamProxy::ReadBlock(pdfium::span<wchar_t> buffer) {
+   if ((leading_bytes & kUtf8Mask) == kUtf8Marker) {
+     return FX_CodePage::kUTF8;
+@@ -196,9 +204,15 @@ size_t CFX_SeekableStreamProxy::ReadBlock(pdfium::span<wchar_t> buffer) {
      size_t bytes_read =
          ReadData(pdfium::as_writable_bytes(buffer).first(bytes_to_read));
      size_t elements = bytes_read / sizeof(uint16_t);


### PR DESCRIPTION
## Summary
- rebase `patches/bigendian.patch` onto the `CFX_SeekableStreamProxy::DetectByteOrderMark()` helper added in newer PDFium
- keep the existing endian-specific BOM constants and UTF-16 byte swap behavior

Fixes #455.

## Testing
- `git apply --check ../pypdfium2/patches/bigendian.patch` against PDFium `chromium/7913`
- `git apply ../pypdfium2/patches/bigendian.patch && git diff --check` against PDFium `chromium/7913`
- same checks against current PDFium `main`
