### PR TITLE
Downgrade i686 build jobs to ubuntu-24.04 base

### DIFF
--- a/PLATFORMS.csv
+++ b/PLATFORMS.csv
@@ -6,15 +6,15 @@ Windows x86_64,⚪ ?,✅🔄 PBIN,🟢 1,✅,✅,✅,⬜,✅,✅,⬜,✅,✅,⬜
 Windows x86,⚪ ?,✅🔄 PBIN,🔵 2,✅,⏸️,✅,🔳,✅,✅,🔳,✅,✅,🔳,clang,NA,
 Windows arm64,⚪ 10?,✅🔄 PBIN,🔵 2,✅,✅,✅,🔳,✅,✅,🔲,✅,✅,🔲,clang,✅,
 Linux glibc x86_64,🟢 2.17,✅🔄 PBIN,🟢 1,✅,✅,✅,⬜,✅,✅,⬜,✅,✅,⬜,gcc,✅,
-Linux glibc i686,🟢 2.17,✅🔄 PBIN,🟢 1-2,✅,⏸️,🚧,🔳,✅,🚧,🔳,✅,🚧,⬜,gcc,✅,[2]_
+Linux glibc i686,🟢 2.17,✅🔄 PBIN,🟢 1-2,✅,⏸️,☑️,🔳,✅,☑️,🔳,✅,☑️,⬜,gcc,✅,
 Linux glibc aarch64,🟢 2.17,✅🔄 PBIN,🟢 1,✅,✅,✅,🔳,✅,✅,🔲,✅,✅,⬜,gcc,✅,
 Linux glibc armv7l,🟢 2.17,✅🔄 PBIN,🟢 1-2,✅,⏸️,☑️,🔳,✅,☑️,🔳,✅,☑️,⬜,gcc,✅,
 Linux glibc ppc64le,🟢 2.17,✅🔄 PBIN,🔵 2-3,✅,✅,☑️,🔳,✅,☑️,🔳,✅,☑️,🔳,clang,☑️,
 Linux glibc s390x,🟡 2.28,✅📌 CIBW,🔴 4,❌,❌,NA,NA,❌,NA,NA,✅,☑️,🔳,clang,☑️,
 Linux glibc riscv64,🟠 2.34,✅📌 CIBW,🟡 3,❌,❌,NA,NA,❌,NA,NA,✅,☑️,🔳,clang,☑️,
 Linux glibc loong64,🔴 2.38,🟩📌 CIBW,🟡 3,❌,❌,NA,NA,❌,NA,NA,✅,☑️,🔳,clang,☑️,
-Linux glibc mips64le,🟢 2.17,🟩🔄 PBIN,🟡 3,✅,❓,☑️,🔳,✅,☑️,🔳,❌,NA,NA,NA,🅿️,[3]_
-Linux glibc mipsle,🟢 2.17,🟩📌 SBLD,🟡 3,✅,❓,❌,🔳,✅,❌,🔳,❌,NA,NA,NA,🅿️,[3]_ [4]_
+Linux glibc mips64le,🟢 2.17,🟩🔄 PBIN,🟡 3,✅,❓,☑️,🔳,✅,☑️,🔳,❌,NA,NA,NA,🅿️,[2]_
+Linux glibc mipsle,🟢 2.17,🟩📌 SBLD,🟡 3,✅,❓,❌,🔳,✅,❌,🔳,❌,NA,NA,NA,🅿️,[2]_ [3]_
 Linux musl x86_64,🟢 1.2,✅🔄 CIBW,🔵 2,✅,❓,✅,🔳,❌,NA,NA,✅,✅,⬜,gcc,✅,
 Linux musl i686,🟢 1.2,✅🔄 CIBW,🔵 2-3,✅,❓,☑️,🔳,❌,NA,NA,✅,☑️,⬜,gcc,✅,
 Linux musl aarch64,🟢 1.2,✅🔄 CIBW,🔵 2,✅,❓,✅,🔳,❌,NA,NA,✅,✅,⬜,gcc,✅,
@@ -23,11 +23,11 @@ Linux musl ppc64le,🟢 1.2,✅📌 CIBW,🟡 3,❌,❌,NA,NA,❌,NA,NA,✅,☑�
 Linux musl s390x,🟢 1.2,✅📌 CIBW,🔴 4,❌,❌,NA,NA,❌,NA,NA,✅,☑️,🔳,clang,☑️,
 Linux musl riscv64,🟢 1.2,✅📌 CIBW,🟡 3,❌,❌,NA,NA,❌,NA,NA,✅,☑️,🔳,clang,☑️,
 Linux musl loong64,🟢 1.2,🟩📌 CIBW,🟡 3,❌,❌,NA,NA,❌,NA,NA,✅,☑️,🔳,clang,☑️,
-Android arm64,🔵 23,✅🔄 PBIN,🔵 2,✅,❓,❌,🔳,✅,❌,🔳,❌,NA,NA,NA,❌ [8]_,
+Android arm64,🔵 23,✅🔄 PBIN,🔵 2,✅,❓,❌,🔳,✅,❌,🔳,❌,NA,NA,NA,❌ [7]_,
 Android armeabi,🔵 23,✅🔄 PBIN,🔵 2,✅,❓,❌,🔳,✅,❌,🔳,❌,NA,NA,NA,❌,
 Android x86_64,🔵 23,🟦🔄 PBIN,⚪ nan,✅,❓,❌,🔳,❌,NA,NA,❌,NA,NA,NA,❌,
 Android x86,🔵 23,🟦🔄 PBIN,⚪ nan,✅,❓,❌,🔳,❌,NA,NA,❌,NA,NA,NA,❌,
-iOS arm64 device,🔴 26,🟨🔄 PBIN,⚪ nan,✅,❓,❌,🔳,❌,NA,NA,❌,NA,NA,NA,NA,[5]_
-iOS arm64 simulator,🔴 26,🟨🔄 PBIN,⚪ nan,✅,❓,❌,🔳,❌,NA,NA,❌,NA,NA,NA,NA,[5]_
-iOS x86_64 simulator,🔴 26,🟨🔄 PBIN,⚪ nan,✅,❓,❌,🔳,❌,NA,NA,❌,NA,NA,NA,NA,[5]_
-PyEmscripten wasm32,🟠 2026,❎📌 CIBW,🔴 4 (!),❌ [6]_,❌,NA,NA,❌,NA,NA,✅,☑️,🔳,emcc,NA,[7]_
+iOS arm64 device,🔴 26,🟨🔄 PBIN,⚪ nan,✅,❓,❌,🔳,❌,NA,NA,❌,NA,NA,NA,NA,[4]_
+iOS arm64 simulator,🔴 26,🟨🔄 PBIN,⚪ nan,✅,❓,❌,🔳,❌,NA,NA,❌,NA,NA,NA,NA,[4]_
+iOS x86_64 simulator,🔴 26,🟨🔄 PBIN,⚪ nan,✅,❓,❌,🔳,❌,NA,NA,❌,NA,NA,NA,NA,[4]_
+PyEmscripten wasm32,🟠 2026,❎📌 CIBW,🔴 4 (!),❌ [5]_,❌,NA,NA,❌,NA,NA,✅,☑️,🔳,emcc,NA,[6]_

--- a/docs/source/platforms.rst
+++ b/docs/source/platforms.rst
@@ -34,17 +34,16 @@ Covered platforms
    :header-rows: 1
 
 .. [1] Since v5.12.0, build strategies used and platforms included may vary between releases. pypdfium2's GitHub releases contain the authoritative strategy info, while this table currently reflects our ``default`` release profile.
-.. [2] Testing is temporarily disabled, due to issues with the Docker container when called from GHA. It does work locally. To be investigated.
-.. [3] MIPS platforms are not officially part of the manylinux standard, so the wheel tags we use are actually rejected by ``pip``, as they are not in its internal whitelist.
+.. [2] MIPS platforms are not officially part of the manylinux standard, so the wheel tags we use are actually rejected by ``pip``, as they are not in its internal whitelist.
    This can be remedied by re-tagging with ``wheel`` locally to match the host's ``sysconfig.get_platform()`` value.
    ``pip`` maintainers have been informed of this situation.
-.. [4] Untested, for lack of a container and binfmt handler.
-.. [5] iOS is untested, and has special considerations regarding the `management of binary extension modules <https://docs.python.org/3/using/ios.html#binary-extension-modules>`_.
+.. [3] Untested, for lack of a container and binfmt handler.
+.. [4] iOS is untested, and has special considerations regarding the `management of binary extension modules <https://docs.python.org/3/using/ios.html#binary-extension-modules>`_.
    You should be prepared to patch the library search path in ``pypdfium2_raw/bindings.py``.
    Pull requests to pypdfium2 and/or ctypesgen welcome.
-.. [6] Though the ``pdfium-binaries`` project does provide WASM builds, they are actually incompatible with Pyodide/ctypes, which require a ``.so`` shared library side module, not a ``.wasm`` blob.
-.. [7] While there is experimental Pyodide build support, the resulting builds are known to be flaky at runtime and susceptible to various types of random crashes. Use with caution and not in a production environment! If you can help fix these issues, please reach out :)
-.. [8] Native compilation on Android (Termux) once worked in the past, with a rather early version of ``build_native.py`` and a pre-PEP738 interpreter, but this broke at some point, and it was eventually decided to remove the code passages. See `here <https://github.com/pypdfium2-team/pypdfium2/blob/35ea0c1687d92f5828d5f84316fddfa311975b03/README.md?plain=1#L224-L279>`_ for historical instructions.
+.. [5] Though the ``pdfium-binaries`` project does provide WASM builds, they are actually incompatible with Pyodide/ctypes, which require a ``.so`` shared library side module, not a ``.wasm`` blob.
+.. [6] While there is experimental Pyodide build support, the resulting builds are known to be flaky at runtime and susceptible to various types of random crashes. Use with caution and not in a production environment! If you can help fix these issues, please reach out :)
+.. [7] Native compilation on Android (Termux) once worked in the past, with a rather early version of ``build_native.py`` and a pre-PEP738 interpreter, but this broke at some point, and it was eventually decided to remove the code passages. See `here <https://github.com/pypdfium2-team/pypdfium2/blob/35ea0c1687d92f5828d5f84316fddfa311975b03/README.md?plain=1#L224-L279>`_ for historical instructions.
 
 Legend
 ^^^^^^

--- a/strategy/targets.json
+++ b/strategy/targets.json
@@ -36,7 +36,7 @@
             "pbin_target": "linux_x64",
             "test_on_host": true},
         "manylinux_i686": {
-            "runner_os": "ubuntu-26.04",
+            "runner_os": "ubuntu-24.04",
             "pbin_target": "linux_x86",
             "test_on_host": false},
         "manylinux_aarch64": {
@@ -128,7 +128,7 @@
         "manylinux_x86_64": {
             "runner_os": "ubuntu-24.04"},
         "manylinux_i686": {
-            "runner_os": "ubuntu-26.04",
+            "runner_os": "ubuntu-24.04",
             "target_cpu": "x86"},
         "manylinux_aarch64": {
             "runner_os": "ubuntu-26.04",
@@ -182,7 +182,7 @@
         "manylinux_x86_64": {
             "runner_os": "ubuntu-26.04"},
         "manylinux_i686": {
-            "runner_os": "ubuntu-26.04"},
+            "runner_os": "ubuntu-24.04"},
         "manylinux_aarch64": {
             "runner_os": "ubuntu-26.04-arm"},
         "manylinux_armv7l": {

--- a/utils/container_driver.py
+++ b/utils/container_driver.py
@@ -144,10 +144,6 @@ def parse_args():
 def main():
     
     args = parse_args()
-    if args.target == "manylinux_i686" and bool(os.getenv("GITHUB_ACTIONS")):
-        print("Debian i686 container has network problems on GHA. Skipping.", file=sys.stderr)
-        return
-    
     cibw_os, cibw_cpu = args.target.split("_", maxsplit=1)
     cibw_cpu = {"loongarch64": "loong64"}.get(cibw_cpu, cibw_cpu)
     docker_cpu = DOCKER_CPU_MAP.get(cibw_cpu, cibw_cpu)


### PR DESCRIPTION
I should have realized it was the update to 26.04 that broke this; I'd thought it just broke randomly.